### PR TITLE
[TASK] Update composer dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2.18.6",
-		"phpunit/phpunit": "^7.5.20 || ^8.5.15",
-		"typo3/testing-framework": "^4.15.3 || ^5 || ^6.8.0",
+		"phpunit/phpunit": "^8.5.15",
+		"typo3/testing-framework": "^5.0.16 || ^6.8.0",
 		"phpstan/phpstan": "^0.12.64"
 	},
 	"suggest": {


### PR DESCRIPTION
TYPO3 9 is no longer supported so we do not need to use older
versions of the dev packages.