### PR TITLE
[TASK] Clean up language labels

### DIFF
--- a/Classes/Linktype/ExternalLinktype.php
+++ b/Classes/Linktype/ExternalLinktype.php
@@ -339,7 +339,7 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
                 if (!$message) {
                     if ($errno !== 0) {
                         // fall back to generic error message
-                        $message = sprintf($lang->getLL('list.report.externalerror'), (string)$errno);
+                        $message = sprintf($lang->getLL('list.report.error.httpstatus.general'), (string)$errno);
                     } else {
                         $message = $exception;
                     }
@@ -354,7 +354,7 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
                 }
                 if (!$message) {
                     // fallback to  generic error message and show exception
-                    $message = $lang->getLL('list.report.networkexception');
+                    $message = $lang->getLL('list.report.error.networkexception');
                     if ($exception !== '') {
                         $message .= ' ('
                             . $exception
@@ -365,14 +365,14 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
 
             case 'loop':
                 $message = sprintf(
-                    $lang->getLL('list.report.redirectloop'),
+                    $lang->getLL('list.report.error.redirectloop'),
                     $exception,
                     ''
                 );
                 break;
 
             case 'tooManyRedirects':
-                $message = $lang->getLL('list.report.tooManyRedirects');
+                $message = $lang->getLL('list.report.error.tooManyRedirects');
                 break;
 
             default:

--- a/Classes/Linktype/FileLinktype.php
+++ b/Classes/Linktype/FileLinktype.php
@@ -83,7 +83,7 @@ class FileLinktype extends AbstractLinktype
      */
     public function getErrorMessage(ErrorParams $errorParams = null): string
     {
-        return $this->getLanguageService()->getLL('list.report.filenotexisting');
+        return $this->getLanguageService()->getLL('list.report.error.file.notexisting');
     }
 
     /**

--- a/Classes/Linktype/InternalLinktype.php
+++ b/Classes/Linktype/InternalLinktype.php
@@ -365,7 +365,7 @@ class InternalLinktype extends AbstractLinktype
                             $custom['content']['wrongPage'] ?? '',
                             $custom['content']['rightPage'] ?? ''
                         ],
-                        $lang->getLL('list.report.contentmoved')
+                        $lang->getLL('list.report.error.contentmoved')
                     );
                     break;
                 default:

--- a/Resources/Private/Language/Module/de.locallang.xlf
+++ b/Resources/Private/Language/Module/de.locallang.xlf
@@ -15,58 +15,12 @@
 				<source>Show this level</source>
 				<target>Zeige diese Ebene</target>
 			</trans-unit>
-			<trans-unit id="label_refresh" resname="label_refresh">
-				<source>Refresh display</source>
-				<target>Anzeige aktualisieren</target>
-			</trans-unit>
-			<trans-unit id="list.status.check.done" resname="list.header">
+
+			<trans-unit id="list.status.check.done" resname="list.status.check.done">
 				<source>Check links done</source>
 				<target>Links prüfen - fertig!</target>
 			</trans-unit>
-			<trans-unit id="list.action.check" resname="list.header">
-				<source>Check links</source>
-				<target>Links prüfen</target>
-			</trans-unit>
-			<trans-unit id="list.header" resname="list.header">
-				<source>Broken links</source>
-				<target>Fehlerhafte Links</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.links.title" resname="list.header">
-				<source>Recheck links</source>
-				<target>Links neu prüfen</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.url.title" resname="list.header">
-				<source>Recheck URL</source>
-				<target>URL neu püfen</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.url.ok.removed" resname="list.header">
-				<source>URL %s was rechecked as valid. Removed %d broken link entries.</source>
-				<target>URL %s wurde neu geprüft und als nicht fehlerhaft befunden. %d Einträge f. fehlerhafte Links entfernt</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.url.notok.removed" resname="list.header">
-				<source>URL %s was rechecked as still invalid but no longer exists in record. Number of broken link entries removed: %d</source>
-				<target>URL %s wurde neu geprüft und immer noch als fehlerhaft befunden. URL ist jedoch nicht mehr im Inhalt enthalten. Anzahl Einträge entfernt: %d</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.url.notok.updated" resname="list.header">
-				<source>URL %s was rechecked as still invalid. Number of broken link entries updated: %d</source>
-				<target>URL %s wurde neu geprüft und immer noch als fehlerhaft befunden. Anzahl Einträge aktualisiert: %d</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.url" resname="list.header">
-				<source>URL %s was rechecked.</source>
-				<target>URL %s wurde neu geprüft.</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.message.checked" resname="list.header">
-				<source>Rechecked links for record: %s</source>
-				<target>Links neu geprüft für Element: %s</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.message.removed" resname="list.header">
-				<source>Record %s was deleted - removed broken links for record.</source>
-				<target>Element %s wurde entfernt - zugehörige fehlerhafte Links wurden aus der Liste entfernt.</target>
-			</trans-unit>
-			<trans-unit id="list.recheck.message.notchanged" resname="list.header">
-				<source>Record %s was not changed - no need to recheck</source>
-				<target>Element %s wurde nicht verändert - kein neu prüfen erforderlich</target>
-			</trans-unit>
+
 			<trans-unit id="list.tableHead.page" resname="list.tableHead.path">
 				<source>Page</source>
 				<target>Seite</target>
@@ -75,27 +29,23 @@
 				<source>Element</source>
 				<target>Element</target>
 			</trans-unit>
-			<trans-unit id="list.tableHead.element.field" resname="list.tableHead.element.field">
-				<source>Field</source>
-				<target>Feld</target>
-			</trans-unit>
-			<trans-unit id="list.tableHead.element.type" resname="list.tableHead.element.type">
+			<trans-unit id="list.tableHead.type" resname="list.tableHead.type">
 				<source>Type</source>
 				<target>Typ</target>
 			</trans-unit>
-			<trans-unit id="list.tableHead.headlink" resname="list.tableHead.headlink">
-				<source>Link</source>
-				<target>Link</target>
+			<trans-unit id="list.tableHead.last_check" resname="list.tableHead.last_check">
+				<source>Checked</source>
+				<target>Geprüft</target>
 			</trans-unit>
-			<trans-unit id="list.tableHead.linktarget" resname="list.tableHead.linktarget">
+			<trans-unit id="list.tableHead.url" resname="list.tableHead.url">
 				<source>URL</source>
 				<target>URL</target>
 			</trans-unit>
-			<trans-unit id="list.tableHead.linkmessage" resname="list.tableHead.linkmessage">
+			<trans-unit id="list.tableHead.error" resname="list.tableHead.error">
 				<source>Error</source>
 				<target>Fehler</target>
 			</trans-unit>
-			<trans-unit id="list.tableHead.lastCheck" resname="list.tableHead.lastCheck">
+			<trans-unit id="list.tableHead.last_check_url" resname="list.tableHead.last_check_url">
 				<source>Checked</source>
 				<target>Geprüft</target>
 			</trans-unit>
@@ -103,25 +53,48 @@
 				<source>Action</source>
 				<target>Aktion</target>
 			</trans-unit>
+
+
+
+			<trans-unit id="list.recheck.links.title" resname="list.recheck.links.title">
+				<source>Recheck links</source>
+				<target>Links neu prüfen</target>
+			</trans-unit>
+			<trans-unit id="list.recheck.url.title" resname="list.recheck.url.title">
+				<source>Recheck URL</source>
+				<target>URL neu püfen</target>
+			</trans-unit>
+			<trans-unit id="list.recheck.url.ok.removed" resname="list.recheck.url.ok.removed">
+				<source>URL %s was rechecked as valid. Removed %d broken link entries.</source>
+				<target>URL %s wurde neu geprüft und als nicht fehlerhaft befunden. %d Einträge f. fehlerhafte Links entfernt</target>
+			</trans-unit>
+			<trans-unit id="list.recheck.url.notok.removed" resname="list.recheck.url.notok.removed">
+				<source>URL %s was rechecked as still invalid but no longer exists in record. Number of broken link entries removed: %d</source>
+				<target>URL %s wurde neu geprüft und immer noch als fehlerhaft befunden. URL ist jedoch nicht mehr im Inhalt enthalten. Anzahl Einträge entfernt: %d</target>
+			</trans-unit>
+			<trans-unit id="list.recheck.url.notok.updated" resname="list.recheck.url.notok.updated">
+				<source>URL %s was rechecked as still invalid. Number of broken link entries updated: %d</source>
+				<target>URL %s wurde neu geprüft und immer noch als fehlerhaft befunden. Anzahl Einträge aktualisiert: %d</target>
+			</trans-unit>
+			<trans-unit id="list.recheck.url" resname="list.recheck.url">
+				<source>URL %s was rechecked.</source>
+				<target>URL %s wurde neu geprüft.</target>
+			</trans-unit>
+			<trans-unit id="list.recheck.message.checked" resname="list.recheck.message.checked">
+				<source>Rechecked links for record: %s</source>
+				<target>Links neu geprüft für Element: %s</target>
+			</trans-unit>
+			<trans-unit id="list.recheck.message.removed" resname="list.recheck.message.removed">
+				<source>Record %s was deleted - removed broken links for record.</source>
+				<target>Element %s wurde entfernt - zugehörige fehlerhafte Links wurden aus der Liste entfernt.</target>
+			</trans-unit>
+			<trans-unit id="list.recheck.message.notchanged" resname="list.recheck.message.notchanged">
+				<source>Record %s was not changed - no need to recheck</source>
+				<target>Element %s wurde nicht verändert - kein neu prüfen erforderlich</target>
+			</trans-unit>
 			<trans-unit id="list.edit" resname="list.edit">
 				<source>Edit element containing this broken link</source>
 				<target>Editiere Element welches fehlerhaften Link enthält</target>
-			</trans-unit>
-			<trans-unit id="list.excludeUrl" resname="list.excludeUrl">
-				<source>Do not check this URL</source>
-				<target>Schließe URL von Linkprüfung aus</target>
-			</trans-unit>
-			<trans-unit id="list.checkNew" resname="list.checkNew">
-				<source>Recheck URL</source>
-				<target>URL neu prüfen</target>
-			</trans-unit>
-			<trans-unit id="list.action.web_layout" resname="list.checkNew">
-				<source>Page layout</source>
-				<target>Seiten-Layout</target>
-			</trans-unit>
-			<trans-unit id="list.edit.field" resname="list.edit.field">
-				<source>Edit field containing this broken link</source>
-				<target>Editiere Feld, welches den fehlerhaften link enthält</target>
 			</trans-unit>
 			<trans-unit id="list.field" resname="list.field">
 				<source>(Field: %s)</source>
@@ -131,18 +104,8 @@
 				<source>no headline</source>
 				<target>keine Überschrift</target>
 			</trans-unit>
-			<trans-unit id="list.info.freshness.stale" resname="list.info.freshness.stale">
-				<source>Broken link information may be outdated.</source>
-				<target>Information zum fehlerhaften Link kann veraltet sein.</target>
-			</trans-unit>
-			<trans-unit id="list.info.freshness.fresh" resname="list.info.freshness.stale">
-				<source>Broken link information is most likely up to date.</source>
-				<target>Information zum fehlerhaften Link ist wahrscheinlich aktuell.</target>
-			</trans-unit>
-			<trans-unit id="list.info.freshness.unknown" resname="list.info.freshness.stale">
-				<source></source>
-				<target></target>
-			</trans-unit>
+
+			<!-- link target error messages -->
 
 			<!-- Error messages for email -->
 
@@ -153,6 +116,10 @@
 
 			<!-- Error messages for pages -->
 
+			<trans-unit id="list.report.error.content.notexisting" resname="list.report.error.content.notexisting">
+				<source>Element does not exist.</source>
+				<target>Element existiert nicht.</target>
+			</trans-unit>
 			<trans-unit id="list.report.error.page.deleted" resname="list.report.error.page.deleted">
 				<source>Page is deleted.</source>
 				<target>Seite wurde gelöscht.</target>
@@ -168,13 +135,13 @@
 				<target>Seite existiert nicht. </target>
 			</trans-unit>
 
-			<trans-unit id="list.report.contentmoved" resname="list.report.contentmoved">
+			<trans-unit id="list.report.error.contentmoved" resname="list.report.error.contentmoved">
 				<source>Element '###title###' [###uid###] is not located on page ###wrongpage###, but on page ###rightpage###.</source>
 				<target>Element '###title###' [###uid###] existiert nicht auf Seite ###wrongpage###, sondern auf Seite ###rightpage###.</target>
 			</trans-unit>
 
 			<!-- deprecated -->
-			<trans-unit id="list.report.contentdeleted" resname="list.report.contentdeleted">
+			<trans-unit id="list.report.error.contentdeleted" resname="list.report.error.contentdeleted">
 				<source>Element '###title###' [###uid###] is deleted.</source>
 				<target>Element  '###title###' [###uid###] wurde gelöscht.</target>
 			</trans-unit>
@@ -193,11 +160,6 @@
 			<trans-unit id="list.report.contentnotexisting" resname="list.report.contentnotexisting">
 				<source>Element [###uid###] does not exist.</source>
 				<target>Element [###uid###] existiert nicht.</target>
-			</trans-unit>
-
-			<trans-unit id="list.report.error.content.notexisting" resname="list.report.error.content.notexisting">
-				<source>Element does not exist.</source>
-				<target>Element existiert nicht.</target>
 			</trans-unit>
 
 			<trans-unit id="list.report.rownotvisible" resname="list.report.rownotvisible">
@@ -224,18 +186,6 @@
 				<source>External link target not reachable.</source>
 				<target>Externe Seite ist nicht erreichbar.</target>
 			</trans-unit>
-			<trans-unit id="list.report.redirectloop" resname="list.report.redirectloop">
-				<source>A redirect loop occurred. (%s: %s)</source>
-				<target>Umleitungsschleife.  (%s: %s)</target>
-			</trans-unit>
-			<trans-unit id="list.report.externalerror" resname="list.report.externalerror">
-				<source>HTTP status code=%s.</source>
-				<target>HTTP status code=%s.</target>
-			</trans-unit>
-			<trans-unit id="list.report.filenotexisting" resname="list.report.filenotexisting">
-				<source>File doesn't exist.</source>
-				<target>Datei existiert nicht.</target>
-			</trans-unit>
 			<trans-unit id="list.report.url.file" resname="list.report.url.file">
 				<source>File</source>
 				<target>Datei</target>
@@ -248,38 +198,36 @@
 				<source>Element</source>
 				<target>Element</target>
 			</trans-unit>
-			<trans-unit id="list.report.timeout" resname="list.report.timeout">
-				<source>Operation timeout. The specified time-out period was reached according to the conditions.</source>
-				<target>Zeitüberschreitung. Der Zugriff auf die externe Seite hat die eingestellte Zeit überschritten.</target>
+
+
+			<!-- link target error messages: external -->
+			<trans-unit id="list.report.error.redirectloop" resname="list.report.error.redirectloop">
+				<source>A redirect loop occurred. (%s: %s)</source>
+				<target>Umleitungsschleife.  (%s: %s)</target>
 			</trans-unit>
-			<trans-unit id="list.report.couldnotresolvehost" resname="list.report.couldnotresolvehost">
-				<source>Could not resolve host. The given remote host was not resolved.</source>
-				<target>Konnte hostnamen nicht auflösen.</target>
+			<trans-unit id="list.report.error.file.notexisting" resname="list.report.error.file.notexisting">
+				<source>File doesn't exist.</source>
+				<target>Datei existiert nicht.</target>
 			</trans-unit>
-			<trans-unit id="list.report.errornetworkdata" resname="list.report.errornetworkdata">
-				<source>Failure with receiving network data.</source>
-				<target>Netzwerkfehler.</target>
-				<target></target>
-			</trans-unit>
-			<trans-unit id="list.report.httpexception" resname="list.report.httpexception">
-				<source>Exception: %s</source>
-				<target>Fehler: %s</target>
-			</trans-unit>
-			<trans-unit id="list.report.tooManyRedirects" resname="list.report.tooManyRedirects">
+			<trans-unit id="list.report.error.tooManyRedirects" resname="list.report.error.tooManyRedirects">
 				<source>Too many redirects.</source>
 				<target>Zu viele Umleitungen.</target>
 			</trans-unit>
-			<trans-unit id="list.report.networkexception" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.networkexception" resname="list.report.error.networkexception">
 				<source>Network error / invalid domain</source>
 				<target>Netzwerkfehler oder ungültige domain</target>
 			</trans-unit>
 
-			<!-- HTTP Status codes -->
-			<trans-unit id="list.report.error.httpstatus.400" resname="list.report.networkexception">
+			<!-- link target error messages: HTTP Status code -->
+			<trans-unit id="list.report.error.httpstatus.general" resname="list.report.error.httpstatus.general">
+				<source>HTTP status code=%s.</source>
+				<target>HTTP status code=%s.</target>
+			</trans-unit>
+			<trans-unit id="list.report.error.httpstatus.400" resname="list.report.error.httpstatus.400">
 				<source>Bad request (400)</source>
 				<target>Die Anfrage ist fehlerhaft (400)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.401" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.httpstatus.401" resname="list.report.error.httpstatus.401">
 				<source>Unauthorized - probably a login is required (401)</source>
 				<target>Keine Authentifizierung - in der Regel login erforderlich (401)</target>
 			</trans-unit>
@@ -291,133 +239,126 @@
 				<source>The requested resource was not found (404)</source>
 				<target>Nicht gefunden (404)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.405" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.httpstatus.405" resname="list.report.error.httpstatus.405">
 				<source>Method not allowed (405)</source>
 				<target>Methode (GET, HEAD etc.) nicht verfügbar (405)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.406" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.httpstatus.406" resname="list.report.error.httpstatus.406">
 				<source>Not Acceptable (406)</source>
 				<target>Die angeforderte Ressource steht nicht in der gewünschten Form zur Verfügung (406)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.410" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.httpstatus.410" resname="list.report.error.httpstatus.410">
 				<source>The requested resource is no longer available (410)</source>
 				<target>Nicht mehr verfügbar (410)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.414" resname="list.report.pagenotfound404">
+			<trans-unit id="list.report.error.httpstatus.414" resname="list.report.error.httpstatus.414">
 				<source>URL too long (414)</source>
 				<target>URL zu lang (414)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.415" resname="list.report.pagenotfound404">
+			<trans-unit id="list.report.error.httpstatus.415" resname="list.report.error.httpstatus.415">
 				<source>Unsupported Media Type (415)</source>
 				<target>Nicht unterstütztes Medium (415)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.429" resname="list.report.pagenotfound404">
+			<trans-unit id="list.report.error.httpstatus.429" resname="list.report.error.httpstatus.429">
 				<source>Too Many Requests (429)</source>
 				<target>Zu viele Anfragen (429)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.451" resname="list.report.pagenotfound404">
+			<trans-unit id="list.report.error.httpstatus.451" resname="list.report.error.httpstatus.451">
 				<source>Unavailable For Legal Reasons (451)</source>
 				<target>Aus rechtlichen Gründen nicht verfügbar (451)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.500" resname="list.report.internalerror500">
+			<trans-unit id="list.report.error.httpstatus.500" resname="list.report.error.httpstatus.500">
 				<source>Internal Server Error (500)</source>
 				<target>Interner Server Fehler (500)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.httpstatus.503" resname="list.report.internalerror500">
+			<trans-unit id="list.report.error.httpstatus.503" resname="list.report.error.httpstatus.503">
 				<source>Service Unavailable (503)</source>
 				<target>Der Server steht vorrübergehend nicht zur Verfügung (503)</target>
 			</trans-unit>
 
 			<!-- libcurl error messages from https://curl.haxx.se/libcurl/c/libcurl-errors.html -->
 			<!-- ignoring various FTP errors here: 10 - 15, 17, 19  and other error that are unlikely -->
-			<trans-unit id="list.report.error.libcurl.1" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.1" resname="list.report.error.libcurl.1">
 				<source>Unsupported protocol.</source>
 				<target>Angegebene Protokoll wird nicht unterstützt.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.2" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.2" resname="list.report.error.libcurl.2">
 				<source>Initialization failed.</source>
 				<target>Initialisierung fehlgeschlagen.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.3" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.3" resname="list.report.error.libcurl.3">
 				<source>The URL was not properly formatted.</source>
 				<target>URL ist nicht korrekt formatiert.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.4" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.4" resname="list.report.error.libcurl.4">
 				<source>Feature not supported.</source>
 				<target>Feature wird nicht unterstützt.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.5" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.5" resname="list.report.error.libcurl.5">
 				<source>Couldn't resolve proxy.</source>
 				<target>Proxy konnte nicht aufgelöst werden.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.6" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.6" resname="list.report.error.libcurl.6">
 				<source>Couldn't resolve host.</source>
 				<target>Konnte Hostnamen nicht auflösen.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.7" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.7" resname="list.report.error.libcurl.7">
 				<source>Failed to connect to host or proxy.</source>
 				<target>Konnte nicht auf externen Host oder Proxy zugreifen.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.8" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.8" resname="list.report.error.libcurl.8">
 				<source>The remote server sent data that could not be parsed.</source>
 				<target>Fehler beim parsen der Antwort.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.9" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.9" resname="list.report.error.libcurl.9">
 				<source>Access denied.</source>
 				<target>Zugriff verweigert.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.16" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.16" resname="list.report.error.libcurl.16">
 				<source>Generic HTTP/2 error.</source>
 				<target>Allgemeiner HTTP/2 Fehler.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.18" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.18" resname="list.report.error.libcurl.18">
 				<source>A file transfer was shorter or larger than expected.</source>
 				<target>Fehler beim Dateitransfer.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.28" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.28" resname="list.report.error.libcurl.28">
 				<source>Timeout: The remote server possibly took too long to answer.</source>
 				<target>Zeitüberschreitung</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.35" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.35" resname="list.report.error.libcurl.35">
 				<source>Problem with SSL / TLS handshake.</source>
 				<target>Problem mit Verschlüsselung (SSL / TLS)</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.47" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.47" resname="list.report.error.libcurl.47">
 				<source>Too many redirects.</source>
 				<target>Zu viele Umleitungen.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.51" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.51" resname="list.report.error.libcurl.51">
 				<source>SSL / TLS certificate not OK.</source>
 				<target>SSL / TLS Zertifikat fehlerhaft.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.55" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.55" resname="list.report.error.libcurl.55">
 				<source>General network error. Send failed.</source>
 				<target>Netzwerkfehler: Fehler beim Senden.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.56" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.56" resname="list.report.error.libcurl.56">
 				<source>General network error. Receive failed.</source>
 				<target>Netzwerkfehler: Fehler beim Empfangen.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.60" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.60" resname="list.report.error.libcurl.60">
 				<source>SSL / TLS certificate not OK.</source>
 				<target>SSL / TLS Zertifikat fehlerhaft.</target>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.63" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.63" resname="list.report.error.libcurl.63">
 				<source>Maximum file size exceeded</source>
 				<target>Maximale Dateigröße wurde überschritten.</target>
 			</trans-unit>
+
 			<trans-unit id="list.msg.ok" resname="list.msg.ok">
 				<source>Ok</source>
 				<target>Ok</target>
 			</trans-unit>
-
-			<!-- deprecated: list.msg.lastRun -->
-			<trans-unit id="list.msg.lastRun" resname="list.msg.lastRun">
-				<source>%1$s %2$s</source>
-				<target>%1$s %2$s</target>
-			</trans-unit>
-
-
 			<trans-unit id="list.no.broken.links" resname="list.no.broken.links">
 				<source>No broken Links!</source>
 				<target>Keine fehlerhaften Links!</target>
@@ -438,10 +379,7 @@
 				<source>You do not have access to these listings.</source>
 				<target>Zugriff verweigert!</target>
 			</trans-unit>
-			<trans-unit id="label_refresh-link-list" resname="label_refresh-link-list">
-				<source>Refreshing link list, please stand by.</source>
-				<target>Linkliste wird aktualisiert.</target>
-			</trans-unit>
+
 			<trans-unit id="broken_links_removed" resname="broken_links_removed">
 				<source>%d broken link(s) removed from list for %s</source>
 				<target>%d fehlerhafte(r) Link(s) wurde entfernt für %s</target>

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -12,86 +12,67 @@
 			<trans-unit id="report.func.title" resname="report.func.title">
 				<source>Show this level</source>
 			</trans-unit>
-			<trans-unit id="label_refresh" resname="label_refresh">
-				<source>Refresh display</source>
-			</trans-unit>
-			<trans-unit id="list.status.check.done" resname="list.header">
+			<trans-unit id="list.status.check.done" resname="list.status.check.done">
 				<source>Check links done</source>
 			</trans-unit>
-			<trans-unit id="list.action.check" resname="list.header">
-				<source>Check links</source>
-			</trans-unit>
-			<trans-unit id="list.header" resname="list.header">
-				<source>Broken links</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.links.title" resname="list.header">
-				<source>Recheck links</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.url.title" resname="list.header">
-				<source>Recheck URL</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.url.ok.removed" resname="list.header">
-				<source>URL %s was rechecked as valid. Removed %d broken link entries.</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.url.notok.removed" resname="list.header">
-				<source>URL %s was rechecked as still invalid but no longer exists in record. Number of broken link entries removed: %d</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.url.notok.updated" resname="list.header">
-				<source>URL %s was rechecked as still invalid. Number of broken link entries updated: %d</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.url" resname="list.header">
-				<source>URL %s was rechecked.</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.message.checked" resname="list.header">
-				<source>Rechecked links for record: %s</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.message.removed" resname="list.header">
-				<source>Record %s was deleted - removed broken links for record</source>
-			</trans-unit>
-			<trans-unit id="list.recheck.message.notchanged" resname="list.header">
-				<source>Record %s was not changed - no need to recheck</source>
-			</trans-unit>
-			<trans-unit id="list.tableHead.page" resname="list.tableHead.path">
+
+
+			<trans-unit id="list.tableHead.page" resname="list.tableHead.page">
 				<source>Page</source>
 			</trans-unit>
 			<trans-unit id="list.tableHead.element" resname="list.tableHead.element">
 				<source>Element</source>
 			</trans-unit>
-			<trans-unit id="list.tableHead.element.field" resname="list.tableHead.element.field">
-				<source>Field</source>
-			</trans-unit>
-			<trans-unit id="list.tableHead.element.type" resname="list.tableHead.element.type">
+			<trans-unit id="list.tableHead.type" resname="list.tableHead.type">
 				<source>Type</source>
 			</trans-unit>
-			<trans-unit id="list.tableHead.headlink" resname="list.tableHead.headlink">
-				<source>Link</source>
+			<trans-unit id="list.tableHead.last_check" resname="list.tableHead.last_check">
+				<source>Checked</source>
 			</trans-unit>
-			<trans-unit id="list.tableHead.linktarget" resname="list.tableHead.linktarget">
+			<trans-unit id="list.tableHead.url" resname="list.tableHead.url">
 				<source>URL</source>
 			</trans-unit>
-			<trans-unit id="list.tableHead.linkmessage" resname="list.tableHead.linkmessage">
+			<trans-unit id="list.tableHead.error" resname="list.tableHead.error">
 				<source>Error</source>
 			</trans-unit>
-			<trans-unit id="list.tableHead.lastCheck" resname="list.tableHead.lastCheck">
+			<trans-unit id="list.tableHead.last_check_url" resname="list.tableHead.last_check_url">
 				<source>Checked</source>
 			</trans-unit>
 			<trans-unit id="list.tableHead.action" resname="list.tableHead.action">
 				<source>Action</source>
 			</trans-unit>
-			<trans-unit id="list.edit" resname="list.edit">
-				<source>Edit element containing this broken link</source>
+
+
+
+			<trans-unit id="list.recheck.links.title" resname="list.recheck.links.title">
+				<source>Recheck links</source>
 			</trans-unit>
-			<trans-unit id="list.excludeUrl" resname="list.excludeUrl">
-				<source>Do not check this URL</source>
-			</trans-unit>
-			<trans-unit id="list.checkNew" resname="list.checkNew">
+			<trans-unit id="list.recheck.url.title" resname="list.recheck.url.title">
 				<source>Recheck URL</source>
 			</trans-unit>
-			<trans-unit id="list.action.web_layout" resname="list.checkNew">
-				<source>Page layout</source>
+			<trans-unit id="list.recheck.url.ok.removed" resname="list.recheck.url.ok.removed">
+				<source>URL %s was rechecked as valid. Removed %d broken link entries.</source>
 			</trans-unit>
-			<trans-unit id="list.edit.field" resname="list.edit.field">
-				<source>Edit field containing this broken link</source>
+			<trans-unit id="list.recheck.url.notok.removed" resname="list.recheck.url.notok.removed">
+				<source>URL %s was rechecked as still invalid but no longer exists in record. Number of broken link entries removed: %d</source>
+			</trans-unit>
+			<trans-unit id="list.recheck.url.notok.updated" resname="list.recheck.url.notok.updated">
+				<source>URL %s was rechecked as still invalid. Number of broken link entries updated: %d</source>
+			</trans-unit>
+			<trans-unit id="list.recheck.url" resname="list.recheck.url">
+				<source>URL %s was rechecked.</source>
+			</trans-unit>
+			<trans-unit id="list.recheck.message.checked" resname="list.recheck.message.checked">
+				<source>Rechecked links for record: %s</source>
+			</trans-unit>
+			<trans-unit id="list.recheck.message.removed" resname="list.recheck.message.removed">
+				<source>Record %s was deleted - removed broken links for record</source>
+			</trans-unit>
+			<trans-unit id="list.recheck.message.notchanged" resname="list.recheck.message.notchanged">
+				<source>Record %s was not changed - no need to recheck</source>
+			</trans-unit>
+			<trans-unit id="list.edit" resname="list.edit">
+				<source>Edit element containing this broken link</source>
 			</trans-unit>
 			<trans-unit id="list.field" resname="list.field">
 				<source>(Field: %s)</source>
@@ -99,15 +80,7 @@
 			<trans-unit id="list.no.headline" resname="list.no.headline">
 				<source>no headline</source>
 			</trans-unit>
-			<trans-unit id="list.info.freshness.stale" resname="list.info.freshness.stale">
-				<source>Broken link information may be outdated.</source>
-			</trans-unit>
-			<trans-unit id="list.info.freshness.fresh" resname="list.info.freshness.fresh">
-				<source>Broken link information is most likely up to date.</source>
-			</trans-unit>
-			<trans-unit id="list.info.freshness.unknown" resname="list.info.freshness.unknown">
-				<source></source>
-			</trans-unit>
+
 
 			<!-- Error messages for email -->
 
@@ -117,22 +90,21 @@
 
 			<!-- Error messages for pages -->
 
+			<trans-unit id="list.report.error.content.notexisting" resname="list.report.error.content.notexisting">
+				<source>Element does not exist.</source>
+			</trans-unit>
 			<trans-unit id="list.report.error.page.deleted" resname="list.report.error.page.deleted">
 				<source>Page is deleted.</source>
 			</trans-unit>
-
 			<trans-unit id="list.report.error.page.notvisible" resname="list.report.error.page.notvisible">
 				<source>Page is hidden.</source>
 			</trans-unit>
-
 			<trans-unit id="list.report.error.page.notexisting" resname="list.report.error.page.notexisting">
 				<source>Page does not exist.</source>
 			</trans-unit>
-
-			<trans-unit id="list.report.contentmoved" resname="list.report.contentmoved">
+			<trans-unit id="list.report.error.contentmoved" resname="list.report.error.contentmoved">
 				<source>Element '###title###' [###uid###] is not located on page ###wrongpage###, but on page ###rightpage###.</source>
 			</trans-unit>
-
 			<!-- deprecated -->
 			<trans-unit id="list.report.contentdeleted" resname="list.report.contentdeleted">
 				<source>Element '###title###' [###uid###] is deleted.</source>
@@ -156,10 +128,6 @@
 				<source>Element [###uid###] does not exist.</source>
 			</trans-unit>
 
-			<trans-unit id="list.report.error.content.notexisting" resname="list.report.error.content.notexisting">
-				<source>Element does not exist.</source>
-			</trans-unit>
-
 			<trans-unit id="list.report.rownotvisible" resname="list.report.rownotvisible">
 				<source>###title### row [###uid###)] is not visible.</source>
 			</trans-unit>
@@ -178,16 +146,6 @@
 			<trans-unit id="list.report.noresponse" resname="list.report.noresponse">
 				<source>External Link not reachable.</source>
 			</trans-unit>
-			<trans-unit id="list.report.redirectloop" resname="list.report.redirectloop">
-				<source>A redirect loop occurred. (%s: %s)</source>
-			</trans-unit>
-			<!-- generic HTTP error -->
-			<trans-unit id="list.report.externalerror" resname="list.report.externalerror">
-				<source>HTTP status code=%s.</source>
-			</trans-unit>
-			<trans-unit id="list.report.filenotexisting" resname="list.report.filenotexisting">
-				<source>File doesn't exist.</source>
-			</trans-unit>
 			<trans-unit id="list.report.url.file" resname="list.report.url.file">
 				<source>File</source>
 			</trans-unit>
@@ -197,31 +155,31 @@
 			<trans-unit id="list.report.url.element" resname="list.report.url.element">
 				<source>Element</source>
 			</trans-unit>
-			<trans-unit id="list.report.timeout" resname="list.report.timeout">
-				<source>Operation timeout. The specified time-out period was reached according to the conditions.</source>
-			</trans-unit>
-			<trans-unit id="list.report.couldnotresolvehost" resname="list.report.couldnotresolvehost">
-				<source>Could not resolve host. The given remote host was not resolved.</source>
-			</trans-unit>
-			<trans-unit id="list.report.errornetworkdata" resname="list.report.errornetworkdata">
-				<source>Failure with receiving network data.</source>
-			</trans-unit>
-			<trans-unit id="list.report.httpexception" resname="list.report.httpexception">
-				<source>Exception: %s</source>
-			</trans-unit>
-			<trans-unit id="list.report.tooManyRedirects" resname="list.report.tooManyRedirects">
+
+
+			<!-- link target error messages: external -->
+
+			<trans-unit id="list.report.error.tooManyRedirects" resname="list.report.error.tooManyRedirects">
 				<source>Too many redirects.</source>
 			</trans-unit>
-			<trans-unit id="list.report.networkexception" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.networkexception" resname="list.report.error.networkexception">
 				<source>Network error / invalid domain</source>
 			</trans-unit>
 			<trans-unit id="list.report.error.other.parse" resname="list.report.networkexception">
 				<source>Unable to parse URI</source>
 			</trans-unit>
+			<trans-unit id="list.report.error.redirectloop" resname="list.report.error.redirectloop">
+				<source>A redirect loop occurred. (%s: %s)</source>
+			</trans-unit>
+			<trans-unit id="list.report.error.file.notexisting" resname="list.report.error.file.notexisting">
+				<source>File doesn't exist.</source>
+			</trans-unit>
 
 
-			<!-- HTTP Status codes -->
-
+			<!-- link target error messages: HTTP Status codes -->
+			<trans-unit id="list.report.error.httpstatus.general" resname="list.report.error.httpstatus.general">
+				<source>HTTP status code=%s.</source>
+			</trans-unit>
 			<trans-unit id="list.report.error.httpstatus.400" resname="list.report.networkexception">
 				<source>Bad request (400)</source>
 			</trans-unit>
@@ -265,72 +223,67 @@
 
 			<!-- libcurl error messages from https://curl.haxx.se/libcurl/c/libcurl-errors.html -->
 			<!-- ignoring various FTP errors here: 10 - 15, 17, 19  and other error that are unlikely -->
-			<trans-unit id="list.report.error.libcurl.1" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.1" resname="list.report.error.libcurl.1">
 				<source>Unsupported protocol.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.2" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.2" resname="list.report.error.libcurl.2">
 				<source>Initialization failed.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.3" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.3" resname="list.report.error.libcurl.3">
 				<source>The URL was not properly formatted.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.4" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.4" resname="list.report.error.libcurl.4">
 				<source>Feature not supported.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.5" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.5" resname="list.report.error.libcurl.5">
 				<source>Couldn't resolve proxy.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.6" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.6" resname="list.report.error.libcurl.6">
 				<source>Couldn't resolve host.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.7" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.7" resname="list.report.error.libcurl.7">
 				<source>Failed to connect to host or proxy.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.8" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.8" resname="list.report.error.libcurl.8">
 				<source>The remote server sent data that could not be parsed.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.9" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.9" resname="list.report.error.libcurl.9">
 				<source>Access denied.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.16" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.16" resname="list.report.error.libcurl.16">
 				<source>Generic HTTP/2 error.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.18" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.18" resname="list.report.error.libcurl.18">
 				<source>A file transfer was shorter or larger than expected.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.28" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.28" resname="list.report.error.libcurl.28">
 				<source>Timeout: The remote server possibly took too long to answer.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.35" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.35" resname="list.report.error.libcurl.35">
 				<source>Problem with SSl / TLS handshake.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.47" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.47" resname="list.report.error.libcurl.47">
 				<source>Too many redirects.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.51" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.51" resname="list.report.error.libcurl.51">
 				<source>SSL / TLS certificate not OK.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.55" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.55" resname="list.report.error.libcurl.55">
 				<source>General network error. Send failed.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.56" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.56" resname="list.report.error.libcurl.56">
 				<source>General network error. Receive failed.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.60" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.60" resname="list.report.error.libcurl.60">
 				<source>SSL / TLS certificate not OK.</source>
 			</trans-unit>
-			<trans-unit id="list.report.error.libcurl.63" resname="list.report.networkexception">
+			<trans-unit id="list.report.error.libcurl.63" resname="list.report.error.libcurl.63">
 				<source>Maximum file size exceeded</source>
 			</trans-unit>
+
 			<trans-unit id="list.msg.ok" resname="list.msg.ok">
 				<source>Ok</source>
 			</trans-unit>
-
-			<!-- deprecated: list.msg.lastRun -->
-			<trans-unit id="list.msg.lastRun" resname="list.msg.lastRun">
-				<source>%1$s %2$s</source>
-			</trans-unit>
-
 			<trans-unit id="list.rootpage"  resname="list.rootpage">
 				<source>Select a page in the page tree!</source>
 			</trans-unit>
@@ -346,9 +299,7 @@
 			<trans-unit id="no.access" resname="no.access">
 				<source>You do not have access to these listings.</source>
 			</trans-unit>
-			<trans-unit id="label_refresh-link-list" resname="label_refresh-link-list">
-				<source>Refreshing link list, please stand by.</source>
-			</trans-unit>
+
 			<trans-unit id="broken_links_removed" resname="broken_links_removed">
 				<source>%d broken link(s) removed from list for %s</source>
 			</trans-unit>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -7,74 +7,52 @@
 				<source>Broken link fixer</source>
 				<target>Links prüfen</target>
 			</trans-unit>
-			<trans-unit id="tasks.validate.name" resname="tasks.validate.name">
-				<source>Broken link fixer</source>
+
+			<!-- broken link list -->
+
+			<trans-unit id="list.header" resname="list.header">
+				<source>Broken links</source>
+				<target>Fehlerhafte Links</target>
+			</trans-unit>
+			<trans-unit id="label_refresh" resname="label_refresh">
+				<source>Refresh display</source>
+				<target>Anzeige aktualisieren</target>
+			</trans-unit>
+			<trans-unit id="label_refresh-link-list" resname="label_refresh-link-list">
+				<source>Refreshing link list, please stand by.</source>
+				<target>Linkliste wird aktualisiert.</target>
+			</trans-unit>
+			<trans-unit id="list.action.checkLinks" resname="list.action.checkLinks">
+				<source>Check links</source>
 				<target>Links prüfen</target>
 			</trans-unit>
-			<trans-unit id="tasks.validate.description" resname="tasks.validate.description">
-				<source>Search for broken links and store the result into the table tx_brofix_broken_links. The results will be displayed in the backend module.</source>
-				<target>Suche nach fehlerhaften Links und speichere die Ergebnisse in der Tabelle tx_brofix_broken_links. Die Ergebnisse werden im backend Modul angezeigt.</target>
+			<trans-unit id="list.info.freshness.stale" resname="list.info.freshness.stale">
+				<source>Broken link information may be outdated.</source>
+				<target>Information zum fehlerhaften Link kann veraltet sein.</target>
+			</trans-unit>
+			<trans-unit id="list.info.freshness.fresh" resname="list.info.freshness.stale">
+				<source>Broken link information is most likely up to date.</source>
+				<target>Information zum fehlerhaften Link ist wahrscheinlich aktuell.</target>
+			</trans-unit>
+			<trans-unit id="list.info.freshness.unknown" resname="list.info.freshness.stale">
+				<source></source>
 				<target></target>
 			</trans-unit>
-			<trans-unit id="tasks.validate.page" resname="tasks.validate.page">
-				<source>Start page (uid)</source>
-				<target>Startseite (uid)</target>
+			<trans-unit id="list.edit.field" resname="list.edit.field">
+				<source>Edit field containing this broken link</source>
+				<target>Editiere Feld, welches den fehlerhaften link enthält</target>
 			</trans-unit>
-			<trans-unit id="tasks.validate.depth" resname="tasks.validate.depth">
-				<source>Depth</source>
-				<target>Tiefe</target>
+			<trans-unit id="list.action.web_layout" resname="list.action.web_layout">
+				<source>Page layout</source>
+				<target>Seiten-Layout</target>
 			</trans-unit>
-			<trans-unit id="tasks.validate.conf" resname="tasks.validate.conf">
-				<source>Overwrite TSconfig</source>
-				<target>Überschreibe TSconfig</target>
+			<trans-unit id="list.action.recheckUrl" resname="list.action.recheckUrl">
+				<source>Recheck URL</source>
+				<target>URL neu prüfen</target>
 			</trans-unit>
-			<trans-unit id="tasks.validate.email" resname="tasks.validate.email">
-				<source>Send email report to</source>
-				<target>Schicke Ergebnisse per E-Mail an</target>
-			</trans-unit>
-			<trans-unit id="tasks.validate.emailOnBrokenLinkOnly" resname="tasks.validate.emailOnBrokenLinkOnly">
-				<source>Send email only if broken links were found</source>
-				<target>Sende email nur wenn fehlerhafte Links gefunden wurden</target>
-			</trans-unit>
-			<trans-unit id="tasks.validate.emailTemplateFile" resname="tasks.validate.emailTemplateFile">
-				<source>Email template file</source>
-				<target>Email template Datei</target>
-			</trans-unit>
-			<trans-unit id="tasks.validate.invalidEmail" resname="tasks.validate.invalidEmail">
-				<source>Invalid email format!</source>
-				<target>Fehlerhaftes E-Mail Format</target>
-			</trans-unit>
-			<trans-unit id="tasks.validate.invalidPage" resname="tasks.validate.invalidPage">
-				<source>Invalid page uid, please enter a valid page uid!</source>
-				<target>Ungültige SeitenID, bitte geben Sie eine gültige Seiten-ID ein!</target>
-			</trans-unit>
-			<trans-unit id="tasks.validate.invalidDepth" resname="tasks.validate.invalidDepth">
-				<source>There is no depth set, please set it to one of the offered values!</source>
-				<target>Tiefe ist nicht gesetzt, bitte auwählen!</target>
-			</trans-unit>
-			<trans-unit id="tasks.error.noSubject" resname="tasks.error.noSubject">
-				<source>No subject for the notification email</source>
-				<target>Betreff fehlt für die Benachrichtigungs-E-Mail.</target>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidToEmail" resname="tasks.error.invalidToEmail">
-				<source>Invalid format of one or more of the recipient email addresses!</source>
-				<target>Ungültiges Format für eine oder mehrere der Empfangs-Adressen (E-Mail)</target>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidFromEmail" resname="tasks.error.invalidFromEmail">
-				<source>Invalid format of the email address in the from header</source>
-				<target>Ungültiges Format für E-Mail Adressen (Absender=From)</target>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidTSconfig" resname="tasks.error.invalidTSconfig">
-				<source>Invalid TSconfig in the task configuration!</source>
-				<target>Ungültiges TSconfig in der Konfiguration des Scheduler task</target>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidEmailTemplateFile" resname="tasks.error.invalidEmailTemplateFile">
-				<source>The email template file is not existing!</source>
-				<target>E-Mail template Datei existiert nicht!</target>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidPageUid" resname="tasks.error.invalidPageUid">
-				<source>The given page id %d is invalid!</source>
-				<target>Die Seiten mit der id %d ist nicht gültig!</target>
+			<trans-unit id="list.action.excludeUrl" resname="list.action.excludeUrl">
+				<source>Permanently exclude this URL from URL checking</source>
+				<target>URL dauerhaft von Linkprüfung ausschließen</target>
 			</trans-unit>
 			<trans-unit id="broken_links_found_for_page" resname="broken_links_found_for_page">
 				<source>Broken links were found on this page</source>
@@ -82,7 +60,7 @@
 			</trans-unit>
 			<trans-unit id="go_to_info_modul" resname="go_to_info_modul">
 				<source>Go to the Info module</source>
-				<target>Ins Info Modul wechseln</target>
+				<target>Zum Info Modul wechseln</target>
 			</trans-unit>
 			<trans-unit id="and_check_links" resname="and_check_links">
 				<source>and check links</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -6,56 +6,41 @@
 			<trans-unit id="mod_brofix" resname="mod_brofix">
 				<source>Broken link fixer</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.name" resname="tasks.validate.name">
-				<source>Broken link fixer</source>
+
+			<!-- broken link list -->
+
+			<trans-unit id="list.header" resname="list.header">
+				<source>Broken links</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.description" resname="tasks.validate.description">
-				<source>Search for broken links and store the result into the temporary table tx_brofix_broken_links in order to ease up the backend module.</source>
+			<trans-unit id="label_refresh" resname="label_refresh">
+				<source>Refresh display</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.page" resname="tasks.validate.page">
-				<source>Start page (uid)</source>
+			<trans-unit id="label_refresh-link-list" resname="label_refresh-link-list">
+				<source>Refreshing link list, please stand by.</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.depth" resname="tasks.validate.depth">
-				<source>Depth</source>
+			<trans-unit id="list.action.checkLinks" resname="list.action.checkLinks">
+				<source>Check links</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.conf" resname="tasks.validate.conf">
-				<source>Overwrite TSconfig</source>
+			<trans-unit id="list.info.freshness.stale" resname="list.info.freshness.stale">
+				<source>Broken link information may be outdated.</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.email" resname="tasks.validate.email">
-				<source>Send email report to</source>
+			<trans-unit id="list.info.freshness.fresh" resname="list.info.freshness.fresh">
+				<source>Broken link information is most likely up to date.</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.emailOnBrokenLinkOnly" resname="tasks.validate.emailOnBrokenLinkOnly">
-				<source>Send email only if broken links were found</source>
+			<trans-unit id="list.info.freshness.unknown" resname="list.info.freshness.unknown">
+				<source></source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.emailTemplateFile" resname="tasks.validate.emailTemplateFile">
-				<source>Email template file</source>
+			<trans-unit id="list.edit.field" resname="list.edit.field">
+				<source>Edit field containing this broken link</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.invalidEmail" resname="tasks.validate.invalidEmail">
-				<source>Invalid email format!</source>
+			<trans-unit id="list.action.web_layout" resname="list.action.web_layout">
+				<source>Page layout</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.invalidPage" resname="tasks.validate.invalidPage">
-				<source>Invalid page uid, please enter a valid page uid!</source>
+			<trans-unit id="list.action.recheckUrl" resname="list.action.recheckUrl">
+				<source>Recheck URL</source>
 			</trans-unit>
-			<trans-unit id="tasks.validate.invalidDepth" resname="tasks.validate.invalidDepth">
-				<source>There is no depth set, please set it to one of the offered values!</source>
-			</trans-unit>
-			<trans-unit id="tasks.error.noSubject" resname="tasks.error.noSubject">
-				<source>No subject for the notification email</source>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidToEmail" resname="tasks.error.invalidToEmail">
-				<source>Invalid format of one or more of the recipient email addresses!</source>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidFromEmail" resname="tasks.error.invalidFromEmail">
-				<source>Invalid format of the email address in the from header</source>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidTSconfig" resname="tasks.error.invalidTSconfig">
-				<source>Invalid TSconfig in the task configuration!</source>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidEmailTemplateFile" resname="tasks.error.invalidEmailTemplateFile">
-				<source>The email template file is not existing!</source>
-			</trans-unit>
-			<trans-unit id="tasks.error.invalidPageUid" resname="tasks.error.invalidPageUid">
-				<source>The given page id %d is invalid!</source>
+			<trans-unit id="list.action.excludeUrl" resname="list.action.excludeUrl">
+				<source>Permaently exclude this URL from URL checking</source>
 			</trans-unit>
 			<trans-unit id="broken_links_found_for_page" resname="broken_links_found_for_page">
 				<source>Broken links were found on this page</source>

--- a/Resources/Private/Templates/Backend/ReportTab.html
+++ b/Resources/Private/Templates/Backend/ReportTab.html
@@ -1,7 +1,7 @@
 <f:layout name="TabContent"/>
 
 <f:section name="header">
-	<f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.header"/>
+	<f:translate key="list.header" extensionName="Brofix">Broken links</f:translate>
 	<f:if condition="{pageTitle}">
 		&quot;{title}&quot;
 	</f:if>
@@ -16,39 +16,33 @@
 			<input type="hidden" name="orderBy" value="{orderBy}"/>
 			<br/>
 			<select id="brofix-list-select-pagedepth" name="depth" class="form-control input-sm">
-				<option value="0" {f:if(condition:
-				'{depth} == 0', then: 'selected')}>
+				<option value="0" {f:if(condition:'{depth} == 0', then: 'selected')}>
 				<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.depth_0"/>
 				</option>
-				<option value="1" {f:if(condition:
-				'{depth} == 1', then: 'selected')}>
+				<option value="1" {f:if(condition:'{depth} == 1', then: 'selected')}>
 				<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.depth_1"/>
 				</option>
-				<option value="2" {f:if(condition:
-				'{depth} == 2', then: 'selected')}>
+				<option value="2" {f:if(condition:'{depth} == 2', then: 'selected')}>
 				<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.depth_2"/>
 				</option>
-				<option value="3" {f:if(condition:
-				'{depth} == 3', then: 'selected')}>
+				<option value="3" {f:if(condition:'{depth} == 3', then: 'selected')}>
 				<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.depth_3"/>
 				</option>
-				<option value="4" {f:if(condition:
-				'{depth} == 4', then: 'selected')}>
+				<option value="4" {f:if(condition:'{depth} == 4', then: 'selected')}>
 				<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.depth_4"/>
 				</option>
-				<option value="999" {f:if(condition:
-				'{depth} == 999', then: 'selected')}>
+				<option value="999" {f:if(condition:'{depth} == 999', then: 'selected')}>
 				<f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.depth_infi"/>
 				</option>
 			</select>
 			<br/>
 			<input type="submit" class="btn btn-default t3js-update-button" name="refreshLinkList" id="refreshLinkList"
-				   value="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:label_refresh')}"
-				   data-notification-message="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:label_refresh-link-list')}"/>
+				   value="{f:translate(key: 'label_refresh', extensionName: 'Brofix')}"
+				   data-notification-message="{f:translate(key: 'label_refresh-link-list', extensionName: 'Brofix')}"/>
 			<f:if condition="{showRecheckButton}">
 				<input type="submit" class="btn btn-default t3js-update-button" name="updateLinkList" id="updateLinkList"
-					   value="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.action.check')}"
-					   data-notification-message="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.action.check')} ..."/>
+					   value="{f:translate(key: 'list.action.checkLinks', extensionName: 'Brofix')}"
+					   data-notification-message="{f:translate(key: 'list.action.check', extensionName: 'Brofix')} ..."/>
 			</f:if>
 			<f:if condition="{docsurl}">
 				<f:link.external class="btn btn-default" uri="{docsurl}" target="_blank">
@@ -67,77 +61,40 @@
 				<thead>
 				<tr>
 					<th class="table-column-divider-end">
-						<f:if condition="{orderBy} == 'page'">
-							<f:then>
-								<a href="{sortActions.page_reverse}" title="Sort by page (descending)"
-								   style="text-decoration: underline;">{tableheadPath}</a>
-								<core:icon identifier="status-status-sorting-asc"/>
-							</f:then>
-							<f:else>
-								<a href="{sortActions.page}" title="Sort by page (ascending)"
-								   style="text-decoration: underline;">{tableheadPath}</a>
-								<f:if condition="{orderBy} == 'page_reverse'">
-									<core:icon identifier="status-status-sorting-desc"/>
-								</f:if>
-							</f:else>
+						<f:format.raw>{tableHeader.page.header}</f:format.raw>
+						<f:if condition="{tableHeader.page.icon}">
+							<core:icon identifier="{tableHeader.page.icon}"/>
 						</f:if>
 					</th>
-					<th>{tableheadElement}</th>
+					<th>{tableHeader.element.header}</th>
 					<th>
-						<f:if condition="{orderBy} == 'field'">
-							<f:then>
-								<a href="{sortActions.field_reverse}" title="Sort by field (descending)"
-								   style="text-decoration: underline;">
-									<f:translate
-										key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.tableHead.element.type"/>
-								</a>
-								<core:icon identifier="status-status-sorting-asc"/>
-							</f:then>
-							<f:else>
-								<a href="{sortActions.field}" title="Sort by field (ascending)"
-								   style="text-decoration: underline;">
-									<f:translate
-										key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.tableHead.element.type"/>
-								</a>
-								<f:if condition="{orderBy} == 'field_reverse'">
-									<core:icon identifier="status-status-sorting-desc"/>
-								</f:if>
-							</f:else>
+						<f:format.raw>{tableHeader.type.header}</f:format.raw>
+						<f:if condition="{tableHeader.type.icon}">
+							<core:icon identifier="{tableHeader.type.icon}"/>
 						</f:if>
 					</th>
-					<th class="table-column-divider-end">{tableheadLastcheck}</th>
+					<th class="table-column-divider-end">
+						<f:format.raw>{tableHeader.last_check.header}</f:format.raw>
+						<f:if condition="{tableHeader.last_check.icon}">
+							<core:icon identifier="{tableHeader.last_check.icon}"/>
+						</f:if>
+					</th>
 					<th colspan="2">
-						<f:if condition="{orderBy} == 'url'">
-							<f:then>
-								<a href="{sortActions.url_reverse}" title="Sort by url (descending)">{tableheadLinktarget}</a>
-								<core:icon identifier="status-status-sorting-asc"/>
-							</f:then>
-							<f:else>
-								<a href="{sortActions.url}" title="Sort by url (ascending)">{tableheadLinktarget}</a>
-								<f:if condition="{orderBy} == 'url_reverse'">
-									<core:icon identifier="status-status-sorting-desc"/>
-								</f:if>
-							</f:else>
+						<f:format.raw>{tableHeader.url.header}</f:format.raw>
+						<f:if condition="{tableHeader.url.icon}">
+							<core:icon identifier="{tableHeader.url.icon}"/>
 						</f:if>
 					</th>
 					<th>
-						<f:if condition="{orderBy} == 'errortype'">
-							<f:then>
-								<a href="{sortActions.errortype_reverse}" title="Sort by error type (descending)">{tableheadLinkmessage}</a>
-								<core:icon identifier="status-status-sorting-asc"/>
-							</f:then>
-							<f:else>
-								<a href="{sortActions.errortype}" title="Sort by error type (ascending)">{tableheadLinkmessage}</a>
-								<f:if condition="{orderBy} == 'errortype_reverse'">
-									<core:icon identifier="status-status-sorting-desc"/>
-								</f:if>
-							</f:else>
+						<f:format.raw>{tableHeader.error.header}</f:format.raw>
+						<f:if condition="{tableHeader.error.icon}">
+							<core:icon identifier="{tableHeader.error.icon}"/>
 						</f:if>
 					</th>
-					<th class="table-column-divider-end">{tableheadLastcheck}<br/> (URL)</th>
+					<th class="table-column-divider-end">
+						{tableHeader.last_check_url.header}<br/>(URL)
 					<th>
-						<f:translate
-							key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.tableHead.action"/>
+						{tableHeader.action.header}
 					</th>
 				</tr>
 				</thead>
@@ -164,7 +121,7 @@
 					<td>{item.elementIcon -> f:format.raw()}<span
 						title="{item.table} {item.field}">{item.elementType}:<br/>{item.fieldName}</span></td>
 					<td class="table-column-divider-end"
-						title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.info.freshness.{item.freshness}')}">
+						title="{f:translate(key: 'list.info.freshness.{item.freshness}', extensionName: 'Brofix')}">
 						<span class="freshness_{item.freshness}">{item.lastcheck}</span>
 						<f:if condition="{item.freshness} == 'stale'>">
 								<core:icon identifier="actions-document-synchronize"/>
@@ -184,23 +141,23 @@
 					<td class="table-column-divider-end">{item.lastcheck_url}</td>
 					<td>
 						<a class="btn btn-primary" href="{item.editUrl}"
-						   title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.edit.field')}">
+						   title="{f:translate(key: 'list.edit.field', extensionName: 'Brofix')}">
 							<core:icon identifier="actions-open" size="small"/>
 						</a>
 						<f:be.link
-							title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.action.web_layout')}"
+							title="{f:translate(key: 'list.action.web_layout', extensionName:'Brofix')}"
 							class="btn btn-default" route="web_layout" parameters="{id:item.pageId}">
 							<core:icon identifier="actions-document-open"/>
 						</f:be.link>
 						<f:if condition="{item.recheckUrl}">
-							<a title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.checkNew')}"
+							<a title="{f:translate(key: 'list.action.recheckUrl', extensionName='Brofix')}"
 							   class="btn btn-default" href="{item.recheckUrl}">
 								<core:icon identifier="actions-synchronize"/>
 							</a>
 						</f:if>
 						<f:if condition="{item.excludeUrl}">
 							<a class="btn btn-default" href="{item.excludeUrl}"
-							   title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.excludeUrl')}">
+							   title="{f:translate(key: 'list.action.excludeUrl', extensionName='Brofix')}">
 								<core:icon identifier="mimetypes-x-exclude-link-target" size="small"/>
 							</a>
 						</f:if>


### PR DESCRIPTION
- Fix inconsistency of id and resname in some language files
- Use shortform of language key in "translate" ViewHelper. Due to
  this the language file locallang.xlf and not Module/locallang.xlf
  should be used.
- Add some missing language labels