### PR TITLE
[BUGFIX] Fix calling undefined function

### DIFF
--- a/Classes/Mail/GenerateCheckResultFluidMail.php
+++ b/Classes/Mail/GenerateCheckResultFluidMail.php
@@ -41,6 +41,10 @@ class GenerateCheckResultFluidMail extends AbstractGenerateCheckResultMail
     public function generateMail(Configuration $config, CheckLinksStatistics $stats, int $pageId): bool
     {
         $templatePaths = new TemplatePaths($GLOBALS['TYPO3_CONF_VARS']['MAIL']);
+
+        /**
+         * @var FluidEmail
+         */
         $fluidEmail = GeneralUtility::makeInstance(FluidEmail::class, $templatePaths);
         $recipients = $config->getMailRecipients();
 
@@ -70,7 +74,7 @@ class GenerateCheckResultFluidMail extends AbstractGenerateCheckResultMail
 
         $replyTo = $config->getMailReplyToEmail();
         if ($replyTo !== '') {
-            $fluidEmail->setReplyTo($replyTo);
+            $fluidEmail->replyTo($replyTo);
         }
         $subject = $config->getMailSubject();
         if ($subject) {

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -10,6 +10,8 @@ Changelog
 =====
 
 *  Fix version constraints (in ext_emconf.php)
+*  Fix fatal error: Exception was thrown on CLI command checklinks if
+   replytoemail was set (due to call to not existing function).
 
 2.1.0
 =====


### PR DESCRIPTION
If replytoemail was set, an undefined function was called which
resulted in an exception (and abort) on sending email after
checking links.
    
Resolves: #66
