### PR TITLE
[BUGFIX] Fix setting depth=0

### DIFF
--- a/Classes/Command/CheckLinksCommand.php
+++ b/Classes/Command/CheckLinksCommand.php
@@ -179,7 +179,16 @@ class CheckLinksCommand extends Command
             return 1;
         }
 
-        $this->depth = (int)($input->getOption('depth') ?: -1);
+        /**
+         * @var string|null $depthOption
+         */
+        $depthOption = $input->getOption('depth');
+        if ($depthOption !== null) {
+            $this->depth = (int)($depthOption);
+        } else {
+            $this->depth = -1;
+        }
+
         $this->sendTo = $input->getOption('to') ?: '';
 
         foreach ($startPages as $pageId) {

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -9,9 +9,12 @@ Changelog
 2.1.1
 =====
 
-*  Fix version constraints (in ext_emconf.php)
+*  Fix setting of depth=0 via CLI command brofix:checklinks
+   (issue:`69 <https://github.com/sypets/brofix/issues/69>`__)
 *  Fix fatal error: Exception was thrown on CLI command checklinks if
    replytoemail was set (due to call to not existing function).
+   (issue:`68 <https://github.com/sypets/brofix/issues/68>`__)
+*  Fix version constraints (in ext_emconf.php)
 
 2.1.0
 =====


### PR DESCRIPTION
If a depth=0 is set via the CLI command brofix:checklinks,
it is interpreted as unset option and the default is used.

Resolves: #69