### PR TITLE
[BUGFIX] Fix alignment in columns of Email report

### DIFF
--- a/Resources/Private/Partials/BrokenLinksStatsTable.html
+++ b/Resources/Private/Partials/BrokenLinksStatsTable.html
@@ -8,6 +8,14 @@
         border-collapse: collapse;
     }
 
+	table.BrokenLinkStats th {
+		text-align: left;
+	}
+
+	table.BrokenLinkStats td {
+		text-align: right;
+	}
+
     table.BrokenLinkStats tr.tableHeader {
         background-color: darkgrey;
         color: white;


### PR DESCRIPTION
The numbers should be aligned on the right side, the text on the
left. This is now fixed in the table of the email report (HTML
version).