### PR TITLE
Show number of broken links in page module

### DIFF
--- a/Classes/Hooks/PageCalloutsHook.php
+++ b/Classes/Hooks/PageCalloutsHook.php
@@ -52,12 +52,17 @@ final class PageCalloutsHook
         $lang = $this->getLanguageService();
 
         // todo: access check
-        if ($this->brokenLinkRepository->hasPageBrokenLinks($pageId)) {
+        $count = $this->brokenLinkRepository->getLinkCountForPage($pageId);
+        if ($count !== 0) {
             $title = '';
             $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-            $uri = (string)$uriBuilder->buildUriFromRoute('web_info', ['id' => $pageId]) . '&SET[function]=Sypets\\Brofix\\View\\BrofixReport';
-            $message = $lang->sL('LLL:EXT:brofix/Resources/Private/Language/locallang.xlf:broken_links_found_for_page');
-            //$message .= '<p><a class="btn btn-info" href="javascript:top.goToModule(\'web_info\',1, \'SET[function]=Sypets%5C%5CBrofix%5C%5CView%5C%5CBrofixReport\');">';
+            $uri = (string)($uriBuilder->buildUriFromRoute('web_info', ['id' => $pageId]) . '&SET[function]=Sypets\\Brofix\\View\\BrofixReport');
+            $message = sprintf(
+                ($count === 1 ? $lang->sL('LLL:EXT:brofix/Resources/Private/Language/locallang.xlf:count_singular_broken_links_found_for_page')
+                        : $lang->sL('LLL:EXT:brofix/Resources/Private/Language/locallang.xlf:count_plural_broken_links_found_for_page'))
+                        ?: '%d broken links were found on this page',
+                $count
+            );
             $message .= '<p><a class="btn btn-info" href="' . $uri . '">';
             $message .= $lang->sL('LLL:EXT:brofix/Resources/Private/Language/locallang.xlf:go_to_info_modul')
                 . '</a> '

--- a/Classes/Repository/BrokenLinkRepository.php
+++ b/Classes/Repository/BrokenLinkRepository.php
@@ -134,8 +134,25 @@ class BrokenLinkRepository implements LoggerAwareInterface
      * @param int $pageId
      * @param bool $withEditableByUser if true, only count broken links for records editable by user
      * @return bool
+     *
+     * @todo use $withEditableByUser
      */
     public function hasPageBrokenLinks(int $pageId, bool $withEditableByUser = true): bool
+    {
+        $count = $this->getLinkCountForPage($pageId, $withEditableByUser);
+        return $count !== 0;
+    }
+
+    /**
+     * Check if current page has broken links editable by user
+     *
+     * @param int $pageId
+     * @param bool $withEditableByUser if true, only count broken links for records editable by user
+     * @return int
+     *
+     * @todo use $withEditableByUser
+     */
+    public function getLinkCountForPage(int $pageId, bool $withEditableByUser = true): int
     {
         $queryBuilder = $this->generateQueryBuilder(self::TABLE);
 
@@ -162,7 +179,7 @@ class BrokenLinkRepository implements LoggerAwareInterface
             )
             ->execute()
             ->fetchColumn(0);
-        return $count !== 0;
+        return $count ?: 0;
     }
 
     /**

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -124,6 +124,14 @@
 				<source>Broken links were found on this page</source>
 				<target>Fehlerhafte Links auf dieser Seite gefunden</target>
 			</trans-unit>
+			<trans-unit id="count_singular_broken_links_found_for_page" resname="count_broken_links_found_for_page">
+				<source>%d broken link was found on this page.</source>
+				<target>%d fehlerhafter Link wurde auf dieser Seite gefunden.</target>
+			</trans-unit>
+			<trans-unit id="count_plural_broken_links_found_for_page" resname="count_broken_links_found_for_page">
+				<source>%d broken links were found on this page.</source>
+				<target>%d fehlerhafte Links wurden auf dieser Seite gefunden.</target>
+			</trans-unit>
 			<trans-unit id="go_to_info_modul" resname="go_to_info_modul">
 				<source>Go to the Info module</source>
 				<target>Zum Info Modul wechseln</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -100,6 +100,12 @@
 			<trans-unit id="broken_links_found_for_page" resname="broken_links_found_for_page">
 				<source>Broken links were found on this page</source>
 			</trans-unit>
+			<trans-unit id="count_singular_broken_links_found_for_page" resname="count_broken_links_found_for_page">
+				<source>%d broken link was found on this page.</source>
+			</trans-unit>
+			<trans-unit id="count_plural_broken_links_found_for_page" resname="count_broken_links_found_for_page">
+				<source>%d broken links were found on this page.</source>
+			</trans-unit>
 			<trans-unit id="go_to_info_modul" resname="go_to_info_modul">
 				<source>Go to the Info module</source>
 			</trans-unit>


### PR DESCRIPTION
Previously we only showed if there were broken links in the page
module, not the number of broken links.

Now, the number of broken links are shown.