### PR TITLE
Optimize pagination

### DIFF
--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -22,6 +22,11 @@ Changelog
    ("Hide default language of page")
 *  Also consider if records should be checked on page if rechecking
    URL or fields.
+*  Optimize external link checking: Do not use extra headers
+   Accept-Language and Accept-Encoding by default. This causes problems with
+   some websites.
+*  Optimize pagination: Do not show pagination controls if there is
+   only one page
 
 2.1.1
 =====

--- a/Resources/Private/Partials/Pagination.html
+++ b/Resources/Private/Partials/Pagination.html
@@ -24,12 +24,12 @@
 				<f:else>
 					<li class="disabled page-item">
 							<span class="page-link">
-								<core:icon identifier="actions-view-paging-first" />
+								<core:icon identifier="empty-empty" />
 							</span>
 					</li>
 					<li class="disabled page-item">
 							<span class="page-link">
-								<core:icon identifier="actions-view-paging-previous" />
+								<core:icon identifier="empty-empty" />
 							</span>
 					</li>
 				</f:else>
@@ -59,12 +59,12 @@
 				<f:else>
 					<li class="disabled page-item">
 							<span class="page-link">
-								<core:icon identifier="actions-view-paging-next" />
+								<core:icon identifier="empty-empty" />
 							</span>
 					</li>
 					<li class="disabled page-item">
 							<span class="page-link">
-								<core:icon identifier="actions-view-paging-last" />
+								<core:icon identifier="empty-empty" />
 							</span>
 					</li>
 				</f:else>

--- a/Resources/Private/Templates/Backend/ReportTab.html
+++ b/Resources/Private/Templates/Backend/ReportTab.html
@@ -51,7 +51,6 @@
 				</f:link.external>
 			</f:if>
 		</form>
-		<f:render partial="Pagination" arguments="{pagination: pagination, currentPage: currentPage, depth: depth, orderBy: orderBy}" />
 	</div>
 </f:section>
 
@@ -168,6 +167,7 @@
 				</f:for>
 				</tbody>
 			</table>
+			<f:render partial="Pagination" arguments="{pagination: pagination, currentPage: currentPage, depth: depth, orderBy: orderBy}" />
 		</f:then>
 	</f:if>
 </f:section>


### PR DESCRIPTION
Show pagination controls on bottom of page.This was recently changed
in the core.

Show icon placeholders instead of disabled icons.