### PR TITLE
[BUGFIX] Fix EditableRestriction for allowed_languages

### DIFF
--- a/Classes/Repository/EditableRestriction.php
+++ b/Classes/Repository/EditableRestriction.php
@@ -80,7 +80,13 @@ class EditableRestriction implements QueryRestrictionInterface
      */
     protected function getAllowedLanguagesForCurrentUser(): array
     {
-        if (!(is_string($GLOBALS['BE_USER']->groupData['allowed_languages'] ?? false))) {
+        /**
+         * Is string of comma-separated languages, e.g. "0,1"
+         *
+         * @var string $allowedLanguages
+         */
+        $allowedLanguages = (string)($GLOBALS['BE_USER']->groupData['allowed_languages'] ?? '');
+        if ($allowedLanguages === '') {
             return [];
         }
 


### PR DESCRIPTION
If no allowed languages are defined for a BE user / group
([allowed_languages] is not set), only broken links in
records of default language were shown for editors.

This is now fixed.

Releases: master
Resolves: #92