### PR TITLE
[TASK] pre-steps on the way to full v11 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,63 +12,75 @@ on:
 jobs:
 
   static:
-    name: static analysis
+    name: "static analysis"
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         php: [ '7.4' ]
+        typo3version: [ '^10.4' ]
         minMax: [ 'composerInstallMax' ]
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: Composer
+      - name: "Set Typo3 core version"
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -c "${{ matrix.typo3version }}" -s composerCoreVersion
+
+      - name: "Composer"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
 
-      - name: cgl
+      - name: "cgl"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cgl -v -n
 
-      - name: Composer validate
+      - name: "Composer validate"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
 
-      - name: Lint PHP
+      - name: "Lint PHP"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
-      - name: phpstan
+      - name: "phpstan"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "-c ../Build/phpstan.neon"
 
   unit:
-    name: Unit tests
+    name: "Unit tests"
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         php: [ '7.2', '7.3', '7.4' ]
+        typo3version: [ '^10.4' ]
         minMax: [ 'composerInstallMin', 'composerInstallMax' ]
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: Composer
+      - name: "Set Typo3 core version"
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -c "${{ matrix.typo3version }}" -s composerCoreVersion
+
+      - name: "Composer"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
 
-      - name: Unit tests
+      - name: "Unit tests"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
 
   functional:
-    name: Functional tests on all DBs
+    name: "Functional tests"
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         php: [ '7.2', '7.3', '7.4' ]
+        typo3version: [ '^10.4']
         minMax: [ 'composerInstallMin', 'composerInstallMax' ]
         #db: [ 'mariadb', 'mssql', 'postgres', 'sqlite' ]
         db: [ 'mariadb' ]
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: Composer
+      - name: "Set Typo3 core version"
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -c "${{ matrix.typo3version }}" -s composerCoreVersion
+
+      - name: "Composer"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
 
-      - name: Functional tests with ${{ matrix.db }}
+      - name: "Functional tests with ${{ matrix.db }}"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d ${{ matrix.db }} -s functional

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
+    - cron:  '42 5 * * *'
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     name: "static analysis"
     runs-on: ubuntu-20.04
     strategy:
+      # This prevents cancellation of matrix job runs, if one/two already failed and let the
+      # rest matrix jobs be be executed anyway.
+      fail-fast: false
       matrix:
         php: [ '7.4' ]
         typo3version: [ '^10.4' ]
@@ -45,6 +48,9 @@ jobs:
     name: "Unit tests"
     runs-on: ubuntu-20.04
     strategy:
+      # This prevents cancellation of matrix job runs, if one/two already failed and let the
+      # rest matrix jobs be be executed anyway.
+      fail-fast: false
       matrix:
         php: [ '7.2', '7.3', '7.4' ]
         typo3version: [ '^10.4' ]
@@ -66,6 +72,9 @@ jobs:
     name: "Functional tests"
     runs-on: ubuntu-20.04
     strategy:
+      # This prevents cancellation of matrix job runs, if one/two already failed and let the
+      # rest matrix jobs be be executed anyway.
+      fail-fast: false
       matrix:
         php: [ '7.2', '7.3', '7.4' ]
         typo3version: [ '^10.4']

--- a/Build/Scripts/ci.sh
+++ b/Build/Scripts/ci.sh
@@ -67,9 +67,9 @@ echo "Running with PHP=$php and $m"
 # composer config preferred-install.typo3/cms-core source
 
 if [[ $vt3 == 10 ]];then
-    Build/Scripts/runTests.sh -p ${php} -c "^10.4" -s
+    Build/Scripts/runTests.sh -p ${php} -c "^10.4" -s composerCoreVersion
 else
-    Build/Scripts/runTests.sh -p ${php} -c "^11.5" -s
+    Build/Scripts/runTests.sh -p ${php} -c "^11.5" -s composerCoreVersion
 fi
 
 echo "composer install"

--- a/Build/Scripts/ci.sh
+++ b/Build/Scripts/ci.sh
@@ -67,10 +67,9 @@ echo "Running with PHP=$php and $m"
 # composer config preferred-install.typo3/cms-core source
 
 if [[ $vt3 == 10 ]];then
-    composer require typo3/cms-backend:^10.4.21
-    composer require typo3/cms-core:^10.4.21
-    composer require typo3/cms-fluid:^10.4.21
-    composer require typo3/cms-info:^10.4.21
+    Build/Scripts/runTests.sh -p ${php} -c "^10.4" -s
+else
+    Build/Scripts/runTests.sh -p ${php} -c "^11.5" -s
 fi
 
 echo "composer install"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -262,7 +262,7 @@ fi
 case ${TEST_SUITE} in
     composerCoreVersion)
         setUpDockerComposeDotEnv
-        docker-compose run composer_corevesion_require
+        docker-compose run composer_coreversion_require
         SUITE_EXIT_CODE=$?
         ;;
     composerInstall)

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -26,6 +26,22 @@ services:
     tmpfs:
       - /var/lib/postgresql/data:rw,noexec,nosuid
 
+  composer_corevesion_require:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+      - ${HOST_HOME}:${HOST_HOME}
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        composer require --no-progress --no-interaction --no-install typo3/minimal:"${CORE_VERSION}";
+      "
   composer_install:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     tmpfs:
       - /var/lib/postgresql/data:rw,noexec,nosuid
 
-  composer_corevesion_require:
+  composer_coreversion_require:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -337,7 +337,7 @@ class LinkAnalyzer implements LoggerAwareInterface
     protected function checkLinks(array $links, array $linkTypes, int $mode = 0): void
     {
         foreach ($this->hookObjectsArr as $key => $hookObj) {
-            if (!is_array($links[$key]) || (!in_array($key, $linkTypes, true))) {
+            if (!is_array($links[$key] ?? false) || (!in_array($key, $linkTypes, true))) {
                 continue;
             }
 

--- a/Classes/Linktype/ExternalLinktype.php
+++ b/Classes/Linktype/ExternalLinktype.php
@@ -421,7 +421,7 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
         $host = (string)($parts['host'] ?? '');
         if ($host !== '') {
             try {
-                $newDomain = (string)HttpUtility::idn_to_ascii($host);
+                $newDomain = (string)idn_to_ascii($host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
                 if (strcmp($host, $newDomain) !== 0) {
                     $parts['host'] = $newDomain;
                     $url = HttpUtility::buildUrl($parts);

--- a/Classes/View/BrofixReport.php
+++ b/Classes/View/BrofixReport.php
@@ -115,7 +115,7 @@ class BrofixReport
     /**
      * @var string
      */
-    protected $orderBy = self::ORDER_BY_DEFAULT;
+    protected $orderBy = BrofixReport::ORDER_BY_DEFAULT;
 
     /**
      * @var int
@@ -417,8 +417,8 @@ class BrofixReport
 
         // orderBy
         $this->orderBy = (string)(GeneralUtility::_GP('orderBy')
-            ?: ($this->pObj->MOD_SETTINGS['orderBy'] ?? self::ORDER_BY_DEFAULT));
-        if ($this->orderBy != ($this->pObj->MOD_SETTINGS['orderBy'] ?? self::ORDER_BY_DEFAULT)) {
+            ?: ($this->pObj->MOD_SETTINGS['orderBy'] ?? BrofixReport::ORDER_BY_DEFAULT));
+        if ($this->orderBy != ($this->pObj->MOD_SETTINGS['orderBy'] ?? BrofixReport::ORDER_BY_DEFAULT)) {
             $resetPagination = true;
         }
         $this->pObj->MOD_SETTINGS['orderBy'] = $this->orderBy;

--- a/Classes/View/BrofixReport.php
+++ b/Classes/View/BrofixReport.php
@@ -25,7 +25,6 @@ use Sypets\Brofix\Linktype\LinktypeInterface;
 use Sypets\Brofix\Repository\BrokenLinkRepository;
 use Sypets\Brofix\Repository\PagesRepository;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
-use TYPO3\CMS\Backend\Template\DocumentTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -121,11 +120,6 @@ class BrofixReport
      * @var int
      */
     protected $paginationCurrentPage;
-
-    /**
-     * @var DocumentTemplate
-     */
-    protected $doc;
 
     /**
      * Information about the current page record

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
 	"require": {
 		"php": "^7.2 || ^7.3 || ^7.4",
 		"sypets/page-callouts": "^1.0.0 || ^2.0.0",
-		"typo3/cms-backend": "^10.4.14 || ^11.5.3",
-		"typo3/cms-core": "^10.4.14 || ^11.5.3",
-		"typo3/cms-fluid": "^10.4.14 || ^11.5.3",
-		"typo3/cms-info": "^10.4.14 || ^11.5.3"
+		"typo3/cms-backend": "^10.4.21 || ^11.5.3",
+		"typo3/cms-core": "^10.4.21 || ^11.5.3",
+		"typo3/cms-fluid": "^10.4.21 || ^11.5.3",
+		"typo3/cms-info": "^10.4.21 || ^11.5.3"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2.18.6",

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -14,7 +14,7 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['MAIL']['partialRootPaths'][901])) {
     $GLOBALS['TYPO3_CONF_VARS']['MAIL']['partialRootPaths'][901] = 'EXT:brofix/Resources/Private/Partials';
 }
 
-if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['brofix']['checkLinks'])) {
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['brofix']['checkLinks'] ?? false)) {
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['brofix']['checkLinks'] = [];
 }
 


### PR DESCRIPTION
This pull-requests contains a collection of commits.
Mainly this collection pins down testing against v10
core only for now, but add first code fixes which are
need to have green v11 core testings.

Besides this, it adds option to jobs strategy to run
all job matrix mutations, even if some failes and avoids
cancellation of the others.

Further we add a scheduled test execution to test default
branch daily on the latest commit. This is helpful to find
out if dependencies release new versions which would than
lead to fails. Take this as a "nightly" test execution.

**Note:** You could see on my fork / branch that every commit
was green during going up these steps: 
https://github.com/sbuerk/brofix/commits/stefan-2      