### PR TITLE
cleanup.sh

### DIFF
--- a/Build/Scripts/ci.sh
+++ b/Build/Scripts/ci.sh
@@ -103,7 +103,7 @@ if [ $cleanup -eq 1 ];then
     $thisdir/cleanup.sh
 else
     echo "--------------------------------------------------------------------------------"
-    echo "!!!! Make sure to run Build/Script/cleanup.sh to revert changes to composer.json"
+    echo "!!!! Make sure to revert changes to composer.json e.g. by git checkout composer.json"
     git diff composer.json
     echo "--------------------------------------------------------------------------------"
 fi

--- a/Build/Scripts/cleanup.sh
+++ b/Build/Scripts/cleanup.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
-rm -rf .Build
-rm composer.lock
+# convenience script for cleaning up after running test suite locally
+# todo: possibly handle restoring of original composer.json file differently
+#  and make sure changes do not get committed accidentally if tests are run locally.
+
 composer config --unset platform.php
 composer config --unset platform
-composer require typo3/cms-backend:"^10.4.14 || ^11.5.3"
-composer require typo3/cms-core:"^10.4.14 || ^11.5.3"
-composer require typo3/cms-fluid:"^10.4.14 || ^11.5.3"
-composer require typo3/cms-info:"^10.4.14 || ^11.5.3"
+
+echo "--------------------------------------------------------------------------------"
+echo "!!!! Make sure to revert changes to composer.json by test suite e.g. by git checkout composer.json"
+git diff composer.json
+echo "--------------------------------------------------------------------------------"
+
+rm -rf .Build
+rm composer.lock


### PR DESCRIPTION
composer require was not executed correctly, should be with
--no-update. We now remove the restoring of the version
because that would have to be updated continuously with the
versions in composer.json.
    
In any case, composer.json can be easily restored manually, e.g.
by git checkout composer.json.
