### PR TITLE
Fixes test-setup issues as preparation vor core v11 testing 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
 
-  all:
+  all_core_10:
     name: "all core-10"
     runs-on: ubuntu-20.04
     strategy:
@@ -63,3 +63,54 @@ jobs:
       - name: "Functional tests with postgres (nightly or pull_request)"
         if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
+
+#  all_core_11:
+#    name: "all core-11"
+#    runs-on: ubuntu-20.04
+#    strategy:
+#      # This prevents cancellation of matrix job runs, if one/two already failed and let the
+#      # rest matrix jobs be be executed anyway.
+#      fail-fast: false
+#      matrix:
+#        php: [ '7.4' ]
+#        minMax: [ 'composerInstallMin', 'composerInstallMax' ]
+#    steps:
+#      - name: "Checkout"
+#        uses: actions/checkout@v2
+#
+#      - name: "Set Typo3 core version"
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -c "^11.5" -s composerCoreVersion
+#
+#      - name: "Composer"
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
+#
+#      - name: "cgl"
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cgl -v -n
+#
+#      - name: "Composer validate"
+#        if: always()
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
+#
+#      - name: "Lint PHP"
+#        if: always()
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+#
+#      - name: "phpstan"
+#        if: ${{ always() && matrix.minMax == 'composerInstallMax' }}
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "-c ../Build/phpstan.neon"
+#
+#      - name: "Unit tests"
+#        if: always()
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
+#
+#      - name: "Functional tests with mariadb"
+#        if: always()
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
+#
+#      - name: "Functional tests with sqlite (nightly or pull_request)"
+#        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
+#
+#      - name: "Functional tests with postgres (nightly or pull_request)"
+#        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
+#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional

--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -50,8 +50,8 @@
                          with TYPO3 core v11 and up.
                          Will always be done with next major version.
                          To still suppress warnings, notices and deprecations, do NOT define the constant at all.
+            <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true" />
          -->
-        <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true" />
         <ini name="display_errors" value="1" />
         <env name="TYPO3_CONTEXT" value="Testing" />
     </php>

--- a/Classes/Command/CheckLinksCommand.php
+++ b/Classes/Command/CheckLinksCommand.php
@@ -92,6 +92,7 @@ class CheckLinksCommand extends Command
     public function __construct(string $name = null)
     {
         parent::__construct($name);
+
         $this->configuration = GeneralUtility::makeInstance(Configuration::class);
         $this->brokenLinkRepository = GeneralUtility::makeInstance(BrokenLinkRepository::class);
         $this->pagesRepository = GeneralUtility::makeInstance(PagesRepository::class);

--- a/Tests/Functional/AbstractFunctionalTest.php
+++ b/Tests/Functional/AbstractFunctionalTest.php
@@ -18,7 +18,6 @@ namespace Sypets\Brofix\Tests\Functional;
  */
 
 use Sypets\Brofix\Configuration\Configuration;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -55,7 +54,6 @@ abstract class AbstractFunctionalTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        Bootstrap::initializeLanguageObject();
         $this->initializeConfiguration();
     }
 

--- a/Tests/Functional/Command/CheckLinksCommandTest.php
+++ b/Tests/Functional/Command/CheckLinksCommandTest.php
@@ -21,10 +21,20 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Sypets\Brofix\Command\CheckLinksCommand;
 use Sypets\Brofix\Exceptions\MissingConfigurationException;
 use Sypets\Brofix\Tests\Functional\AbstractFunctionalTest;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class CheckLinksCommandTest extends AbstractFunctionalTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class);
+        $GLOBALS['LANG'] = $this->getContainer()->get(LanguageServiceFactory::class)->create('default');
+    }
+
     /**
      * @test
      */

--- a/Tests/Functional/LinkAnalyzerTest.php
+++ b/Tests/Functional/LinkAnalyzerTest.php
@@ -18,10 +18,17 @@ namespace Sypets\Brofix\Tests\Functional;
  */
 
 use Sypets\Brofix\LinkAnalyzer;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class LinkAnalyzerTest extends AbstractFunctionalTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['LANG'] = $this->getContainer()->get(LanguageServiceFactory::class)->create('default');
+    }
+
     /**
      * @param array<string|int> $pidList
      * @return LinkAnalyzer

--- a/Tests/Functional/Repository/BrokenLinkRepositoryTest.php
+++ b/Tests/Functional/Repository/BrokenLinkRepositoryTest.php
@@ -21,6 +21,7 @@ use Sypets\Brofix\Filter\Filter;
 use Sypets\Brofix\LinkAnalyzer;
 use Sypets\Brofix\Repository\BrokenLinkRepository;
 use Sypets\Brofix\Tests\Functional\AbstractFunctionalTest;
+use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class BrokenLinkRepositoryTest extends AbstractFunctionalTest
@@ -662,6 +663,7 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
         }
         $this->backendUserFixture = $fixtureFile;
         $this->setUpBackendUserFromFixture($uid);
+        Bootstrap::initializeLanguageObject();
     }
 
     /**


### PR DESCRIPTION
This pull-request contains two commits. The first one
refactors testcases to fix test setup issues, which 
are no longer compatible with core v11 testing. Most
of them are adaptopted from core changes preparing 
core testing with E_ALL and PHP 8.0/8.1 testing with
disabled exception/error handlers.

The second one adds out-commented entries to the ci
github action workflow as preparation, to be easier
enabled after last v11 core testing issue is analyzed
and fixed.

Anyway, running v11 tests could already be done locally
using `Build/Scripts/runTests.sh`, to analyze last core
v11 issue.