### PR TITLE
Ensure LinkAnalzer works with core v11 (tests) and activate CI core v11 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,53 +64,53 @@ jobs:
         if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
 
-#  all_core_11:
-#    name: "all core-11"
-#    runs-on: ubuntu-20.04
-#    strategy:
-#      # This prevents cancellation of matrix job runs, if one/two already failed and let the
-#      # rest matrix jobs be be executed anyway.
-#      fail-fast: false
-#      matrix:
-#        php: [ '7.4' ]
-#        minMax: [ 'composerInstallMin', 'composerInstallMax' ]
-#    steps:
-#      - name: "Checkout"
-#        uses: actions/checkout@v2
-#
-#      - name: "Set Typo3 core version"
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -c "^11.5" -s composerCoreVersion
-#
-#      - name: "Composer"
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
-#
-#      - name: "cgl"
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cgl -v -n
-#
-#      - name: "Composer validate"
-#        if: always()
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
-#
-#      - name: "Lint PHP"
-#        if: always()
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
-#
-#      - name: "phpstan"
-#        if: ${{ always() && matrix.minMax == 'composerInstallMax' }}
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "-c ../Build/phpstan.neon"
-#
-#      - name: "Unit tests"
-#        if: always()
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
-#
-#      - name: "Functional tests with mariadb"
-#        if: always()
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
-#
-#      - name: "Functional tests with sqlite (nightly or pull_request)"
-#        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
-#
-#      - name: "Functional tests with postgres (nightly or pull_request)"
-#        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
-#        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
+  all_core_11:
+    name: "all core-11"
+    runs-on: ubuntu-20.04
+    strategy:
+      # This prevents cancellation of matrix job runs, if one/two already failed and let the
+      # rest matrix jobs be be executed anyway.
+      fail-fast: false
+      matrix:
+        php: [ '7.4' ]
+        minMax: [ 'composerInstallMin', 'composerInstallMax' ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Set Typo3 core version"
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -c "^11.5" -s composerCoreVersion
+
+      - name: "Composer"
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
+
+      - name: "cgl"
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cgl -v -n
+
+      - name: "Composer validate"
+        if: always()
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
+
+      - name: "Lint PHP"
+        if: always()
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+
+      - name: "phpstan"
+        if: ${{ always() && matrix.minMax == 'composerInstallMax' }}
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "-c ../Build/phpstan.neon"
+
+      - name: "Unit tests"
+        if: always()
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
+
+      - name: "Functional tests with mariadb"
+        if: always()
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
+
+      - name: "Functional tests with sqlite (nightly or pull_request)"
+        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
+
+      - name: "Functional tests with postgres (nightly or pull_request)"
+        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -649,7 +649,7 @@ class LinkAnalyzer implements LoggerAwareInterface
                     $softRefParams = $spParams;
                     if (!is_array($softRefParams)) {
                         // set subst such that findRef will return substitutes for urls, emails etc
-                        $softRefParams = ['subst' => true];
+                        $softRefParams = ['subst'];
                     }
 
                     // Do processing


### PR DESCRIPTION
This pull-request contains following points:

- Fix issue in LinkAnalyzer which failed on core v11
- Activate github CI testing against core v11 with PHP 7.4

Issue with LinkAnalzer was an incorrectly set parameter for
the softRef parser, which was invoked. This worked with v10
due an incorrect (unstrict) in_array() check in core, which
was fixed in core v11, thus failing now.

The first commit sets the parameter now correctly, which was
also fixed in core already for v11 for the core LinkAnalyzer.