### PR TITLE
[TASK] Enhance testing capatibilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
+      # This must be checked before core version select is run, as this would write this
+      # and than the check would fail - obiously.
+      - name: "Check if typo3/minimal has been pushed in composer.json"
+        run: Build/Scripts/checkComposerJsonForPushedMinimalPackage.sh
+
       - name: "Set Typo3 core version"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t "^10.4" -s composerCoreVersion
 
@@ -77,6 +82,11 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
+
+      # This must be checked before core version select is run, as this would write this
+      # and than the check would fail - obiously.
+      - name: "Check if typo3/minimal has been pushed in composer.json"
+        run: Build/Scripts/checkComposerJsonForPushedMinimalPackage.sh
 
       - name: "Set Typo3 core version"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t "^11.5" -s composerCoreVersion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
 
       - name: "cgl"
+        if: ${{ matrix.php != '8.1' }}
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cgl -v -n
 
       - name: "Composer validate"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Set Typo3 core version"
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -c "^10.4" -s composerCoreVersion
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t "^10.4" -s composerCoreVersion
 
       - name: "Composer"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Set Typo3 core version"
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -c "^11.5" -s composerCoreVersion
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t "^11.5" -s composerCoreVersion
 
       - name: "Composer"
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}

--- a/Build/Scripts/cglFixMyCommit.sh
+++ b/Build/Scripts/cglFixMyCommit.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+#########################
+#
+# CGL fix.
+#
+# It expects to be run from the core root.
+#
+# To auto-fix single files, use the php-cs-fixer command directly
+# substitute $FILE with a filename
+#
+##########################
+
+# --------------------------
+# --- default parameters ---
+# --------------------------
+# check files in last commit
+filestype=commit
+# non-dryrun is default
+DRYRUN=""
+DRYRUN_OPTIONS="--dry-run --diff"
+
+# ----------------------
+# --- automatic vars ---
+# ----------------------
+progname=$(basename $0)
+
+# ------------------------
+# --- print usage info ---
+# ------------------------
+usage()
+{
+    echo "Usage: $0 [options]                                      "
+    echo " "
+    echo "no arguments/default: fix all php files in last commit   "
+    echo " "
+    echo "Options:                                                 "
+    echo " -f <commit|cache|stdin>                                 "
+    echo "      specifies which files to check:                    "
+    echo "      - commit (default): all files in latest commit     "
+    echo "      - cache : all files in git cache (staging area)    "
+    echo "      - stdin : read list of files from stdin            "
+    echo " "
+    echo " -n                                                      "
+    echo "      dryrun only, do not fix anything!                  "
+    echo " "
+    echo " -h                                                      "
+    echo "      help                                               "
+    echo " "
+    echo "Note: In order to still support command line options of  "
+    echo " older versions of this script, you can use the argument "
+    echo " dryrun.                                                 "
+    echo " "
+    echo " THIS IS NOT RECOMMENDED but will still work for now     "
+    echo " Usage: $0 [options] [dryrun]                            "
+    exit 0
+}
+
+# -----------------------
+# --- parsing of args ---
+# -----------------------
+OPTIND=1
+
+while getopts "hnf:" opt;do
+    case "$opt" in
+    h)
+        usage
+        ;;
+    f)
+        filestype=$OPTARG
+        echo "$0 files type=$filestype"
+        ;;
+    n)
+        echo "$progname: dryrun mode"
+        DRYRUN="$DRYRUN_OPTIONS"
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+if [ "$1" = "dryrun" ]
+then
+    echo "$progname: dryrun mode"
+    DRYRUN="$DRYRUN_OPTIONS"
+fi
+
+# --------------------------------------
+# --- check if php executable exists ---
+# --------------------------------------
+exist_php_executable() {
+    which php >/dev/null 2>/dev/null
+    if [ $? -ne 0 ];then
+        echo "$progname: No php executable found\n"
+        exit 1
+    fi
+}
+
+
+# ------------------------------
+# --- run php without xdebug ---
+# ------------------------------
+php_no_xdebug ()
+{
+    temporaryPath="$(mktemp -t php.XXXX).ini"
+    php -i | grep "\.ini" | grep -o -e '\(/[A-Za-z0-9._-]\+\)\+\.ini' | grep -v xdebug | xargs awk 'FNR==1{print ""}1' > "${temporaryPath}"
+    php -n -c "${temporaryPath}" "$@"
+    RETURN=$?
+    rm -f "${temporaryPath}"
+    exit $RETURN
+}
+
+# ------------------------------------
+# --- get a list of files to check ---
+# ------------------------------------
+if [[ $filestype == commit ]];then
+    echo "$progname: Searching for php files in latest git commit ..."
+    DETECTED_FILES=`git diff-tree --no-commit-id --name-only -r HEAD | grep '.php$' 2>/dev/null`
+elif [[ $filestype == cache ]];then
+    echo "$progname: Searching for php files in git cache ..."
+    DETECTED_FILES=`git diff --cached --name-only | grep '.php$' 2>/dev/null`
+elif [[ $filestype == stdin ]];then
+    echo "$progname: reading list of php files to check from stdin"
+    DETECTED_FILES=$(cat)
+else
+    echo "$progname: ERROR: unknown filetype, possibly used -f with wrong argument"
+    usage
+fi
+if [ -z "${DETECTED_FILES}" ]
+then
+    echo "$progname: No PHP files to check, all is well."
+    exit 0
+fi
+
+# ---------------------------------
+# --- run php-cs-fixer on files ---
+# ---------------------------------
+exist_php_executable
+php_no_xdebug .Build/bin/php-cs-fixer fix \
+    -v ${DRYRUN} \
+    --path-mode intersection \
+    --config=Build/php-cs-fixer.php \
+    `echo ${DETECTED_FILES} | xargs ls -d 2>/dev/null`
+
+exit $?

--- a/Build/Scripts/checkComposerJsonForPushedMinimalPackage.sh
+++ b/Build/Scripts/checkComposerJsonForPushedMinimalPackage.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+TMP="$( cat composer.json | grep "typo3/minimal" )"
+[[ "$?" -ne 1 ]] && echo "[FAIL] 'typo3/minimal' package requirement was pushed in composer.json, remove this." && exit 1
+
+echo "[OK] composer.json clean, no 'typo3/minimal' found in composer.json" && exit 0

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -72,7 +72,7 @@ Options:
             - unit (default): PHP unit tests
             - functional: functional tests
 
-    -c <composer-core-version-constraint>
+    -t <composer-core-version-constraint>
         Only with -s composerCoreVersion
         Specifies the Typo3 core version to be used
             - '^10.4' (default)
@@ -177,12 +177,12 @@ OPTIND=1
 # Array for invalid options
 INVALID_OPTIONS=();
 # Simple option parsing based on getopts (! not getopt)
-while getopts ":s:c:d:p:e:xy:huvn" OPT; do
+while getopts ":s:t:d:p:e:xy:huvn" OPT; do
     case ${OPT} in
         s)
             TEST_SUITE=${OPTARG}
             ;;
-        c)
+        t)
             CORE_VERSION=${OPTARG}
             ;;
         d)

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -65,8 +65,8 @@ Options:
             - composerInstallMin: "composer update --prefer-lowest", with platform.php set to PHP version x.x.0.
             - composerValidate: "composer validate"
             - composerCoreVersion: "composer require --no-install typo3/minimal:"coreVersion"
+            - cgl: test and fix all core php files
             - cglGit: test and fix latest committed patch for CGL compliance
-            - cglAll: test and fix all core php files
             - lint: PHP linting
             - phpstan: phpstan tests
             - unit (default): PHP unit tests
@@ -114,7 +114,7 @@ Options:
         is not listening on default port.
 
     -n
-        Only with -s cglGit|cglAll
+        Only with -s cgl|cglGit
         Activate dry-run in CGL check that does not actively change files and only prints broken ones.
 
     -u
@@ -292,10 +292,17 @@ case ${TEST_SUITE} in
     cgl)
         # Active dry-run for cglAll needs not "-n" but specific options
         if [[ ! -z ${CGLCHECK_DRY_RUN} ]]; then
-            CGLCHECK_DRY_RUN="--dry-run --diff --diff-format udiff"
+            CGLCHECK_DRY_RUN="--dry-run --diff"
         fi
         setUpDockerComposeDotEnv
         docker-compose run cgl_all
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    cglGit)
+        # Active dry-run for cglAll needs not "-n" but specific options
+        setUpDockerComposeDotEnv
+        docker-compose run cgl_git
         SUITE_EXIT_CODE=$?
         docker-compose down
         ;;

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -285,15 +285,27 @@ services:
           bin/phpunit -c Web/typo3conf/ext/brofix/Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
         fi
       "
+
+  cgl_git:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        Build/Scripts/cglFixMyCommit.sh ${CGLCHECK_DRY_RUN};
+      "
+
   cgl_all:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
-      - ${CORE_ROOT}:${CORE_ROOT}
-      - ${HOST_HOME}:${HOST_HOME}
-      - ${PASSWD_PATH}:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
-    working_dir: ${CORE_ROOT}
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
     command: >
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"bin-dir": ".Build/bin"
 	},
 	"require": {
-		"php": "^7.2 || ^7.3 || ^7.4",
+		"php": "^7.2 || ^7.3 || ^7.4 || ^8.0 || ^8.1",
 		"sypets/page-callouts": "^1.0.0 || ^2.0.0",
 		"typo3/cms-backend": "^10.4.21 || ^11.5.3",
 		"typo3/cms-core": "^10.4.21 || ^11.5.3",
@@ -37,7 +37,7 @@
 		"jangregor/phpstan-prophecy": "^0.8.1",
 		"phpstan/phpstan": "^0.12.64",
 		"phpunit/phpunit": "^8.5.21",
-		"typo3/testing-framework": "^6.14.0"
+		"typo3/testing-framework": "^6.15.1"
 	},
 	"suggest": {
 	},

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"typo3/cms-info": "^10.4.21 || ^11.5.3"
 	},
 	"require-dev": {
-		"friendsofphp/php-cs-fixer": "^2.18.6",
+		"friendsofphp/php-cs-fixer": "^3.2",
 		"jangregor/phpstan-prophecy": "^0.8.1",
 		"phpstan/phpstan": "^0.12.64",
 		"phpunit/phpunit": "^8.5.21",


### PR DESCRIPTION
This pull-requests enhance the testing capatibilities of this
repository with a bunch of changes.

- cgl & cglGit is runnable in runTests.sh and adjusted for the future
- Build/Scripts/cglFixMyCommit.sh added (needed for cglGit)
- raised friendsofphp/php-cs-fixer (needed for execution with PHP 8.0)
  =>  in ci workflow disabled for PHP8.1 pro-activly, as there is no
      compatible package yet available for PHP 8.1
- Rename option core versions selection from '-c' to '-t' in runTests.sh
  and adjusted in github ci workflow
- added validation script to check if typo3/minimal was pushed in composer.json
- raised testing-framework:^6.15.1 and added PHP8.0/8.1 support to composer.json


Follow up would be to raise phpstan/phpstan with jangregor/phpstan-prophecy,
but this is not possible yet as this would fail because of several issues in
the code, which futher prevents to enable PHP 8.0 (and PHP 8.1) testing in
github co workflow.