### PR TITLE
[TASK] Enable github ci testing for v11 / PHP8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       # rest matrix jobs be be executed anyway.
       fail-fast: false
       matrix:
-        php: [ '7.4' ]
+        php: [ '7.4', '8.0' ]
         minMax: [ 'composerInstallMin', 'composerInstallMax' ]
     steps:
       - name: "Checkout"


### PR DESCRIPTION
This pull-requests enables testing against core v11 with PHP8.0 in github ci testing.

Nothing more to say here ;)