### PR TITLE
[BUGFIX] Avoid phpstan errors and use correct dbal methods per version

### DIFF
--- a/Classes/CheckLinks/ExcludeLinkTarget.php
+++ b/Classes/CheckLinks/ExcludeLinkTarget.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\CheckLinks;
 
+use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -110,7 +111,7 @@ class ExcludeLinkTarget
                 ...$constraints
             )
             ->execute()
-            ->fetchColumn(0));
+            ->{DoctrineDbalMethodNameHelper::fetchOne()}());
         return $count > 0;
     }
 
@@ -137,7 +138,7 @@ class ExcludeLinkTarget
                     )
                 )
                 ->execute()
-                ->fetch();
+                ->{DoctrineDbalMethodNameHelper::fetchAssociative()}();
 
             return $GLOBALS['BE_USER']->doesUserHaveAccess($row, 16);
         }

--- a/Classes/CheckLinks/LinkTargetCache/LinkTargetPersistentCache.php
+++ b/Classes/CheckLinks/LinkTargetCache/LinkTargetPersistentCache.php
@@ -16,6 +16,7 @@ namespace Sypets\Brofix\CheckLinks\LinkTargetCache;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -61,7 +62,7 @@ class LinkTargetPersistentCache extends AbstractLinkTargetCache
             ->from(static::TABLE)
             ->where(...$constraints)
             ->execute()
-            ->fetchColumn(0) ? true : false;
+            ->{DoctrineDbalMethodNameHelper::fetchOne()}() ? true : false;
     }
 
     /**
@@ -88,7 +89,7 @@ class LinkTargetPersistentCache extends AbstractLinkTargetCache
             );
         $row = $queryBuilder
             ->execute()
-            ->fetch();
+            ->{DoctrineDbalMethodNameHelper::fetchAssociative()}();
         if (!$row) {
             return [];
         }

--- a/Classes/DoctrineDbalMethodNameHelper.php
+++ b/Classes/DoctrineDbalMethodNameHelper.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sypets\Brofix;
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * Small helper for supporting core v10/v11 and changes in doctrine/dbal accros version,
+ * but be fully compatible for full doctrine/dbal version range used from core v10 to v11.
+ *
+ * This whole class can vanish if branches are splitt and we are on core v11 as min core version
+ * or doctrine/dbal:^2.13.6 (which would break v10 legacy install support).
+ *
+ * @internal
+ */
+class DoctrineDbalMethodNameHelper
+{
+    /** @var DoctrineDbalMethodNameHelper|null */
+    protected static $instance;
+
+    /** @var Typo3Version */
+    private $coreVersion;
+
+    /** @var string[][] */
+    private $methodMap = [
+        10 => [
+            'fetchAssociative' => 'fetch',
+            'fetchAllAssociative' => 'fetchAll',
+            'fetchOne' => 'fetchColumn',
+        ],
+    ];
+
+    public function __construct()
+    {
+        $this->coreVersion = new Typo3Version();
+    }
+
+    public function getMethodName(string $methodName): string
+    {
+        $map = $this->methodMap[$this->coreVersion->getMajorVersion()] ?? [];
+        return $map[$methodName] ?? $methodName;
+    }
+
+    /**
+     * @deprecated Replace calls to this method if min core version is at least v11 or doctrine/dbal:^2.13.6
+     */
+    public static function fetchAssociative(): string
+    {
+        return self::get()->getMethodName('fetchAssociative');
+    }
+
+    /**
+     * @deprecated Replace calls to this method if min core version is at least v11 or doctrine/dbal:^2.13.6
+     */
+    public static function fetchAllAssociative(): string
+    {
+        return self::get()->getMethodName('fetchAllAssociative');
+    }
+
+    /**
+     * @deprecated Replace calls to this method if min core version is at least v11 or doctrine/dbal:^2.13.6
+     */
+    public static function fetchOne(): string
+    {
+        return self::get()->getMethodName('fetchOne');
+    }
+
+    protected static function get(): DoctrineDbalMethodNameHelper
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+}

--- a/Classes/Repository/BrokenLinkRepository.php
+++ b/Classes/Repository/BrokenLinkRepository.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception\TableNotFoundException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Sypets\Brofix\CheckLinks\ExcludeLinkTarget;
+use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use Sypets\Brofix\Filter\Filter;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -145,7 +146,7 @@ class BrokenLinkRepository implements LoggerAwareInterface
                 );
             }
 
-            $results = array_merge($results, $queryBuilder->execute()->fetchAll());
+            $results = array_merge($results, $queryBuilder->execute()->{DoctrineDbalMethodNameHelper::fetchAllAssociative()}());
         }
         return $results;
     }
@@ -206,7 +207,7 @@ class BrokenLinkRepository implements LoggerAwareInterface
             }
         }
 
-        $results = array_merge($results, $queryBuilder->execute()->fetchAll());
+        $results = array_merge($results, $queryBuilder->execute()->{DoctrineDbalMethodNameHelper::fetchAllAssociative()}());
         return $results;
     }
 
@@ -276,7 +277,7 @@ class BrokenLinkRepository implements LoggerAwareInterface
                 )
             )
             ->execute()
-            ->fetchColumn(0);
+            ->{DoctrineDbalMethodNameHelper::fetchOne()}();
         return $count ?: 0;
     }
 
@@ -339,7 +340,7 @@ class BrokenLinkRepository implements LoggerAwareInterface
                 ->groupBy(self::TABLE . '.link_type')
                 ->execute();
 
-            while ($row = $result->fetch()) {
+            while ($row = $result->{DoctrineDbalMethodNameHelper::fetchAssociative()}()) {
                 if (!isset($markerArray[$row['link_type']])) {
                     $markerArray[$row['link_type']] = 0;
                 }
@@ -548,7 +549,7 @@ class BrokenLinkRepository implements LoggerAwareInterface
                 );
             return (bool)$queryBuilder
                 ->execute()
-                ->fetchColumn(0);
+                ->{DoctrineDbalMethodNameHelper::fetchOne()}();
         } catch (TableNotFoundException $e) {
             return false;
         }
@@ -639,7 +640,7 @@ class BrokenLinkRepository implements LoggerAwareInterface
                 )
             )
             ->execute()
-            ->fetchColumn(0);
+            ->{DoctrineDbalMethodNameHelper::fetchOne()}();
         if ($count > 0) {
             $identifier = [
                 'record_uid' => $record['record_uid'],

--- a/Classes/Repository/ContentRepository.php
+++ b/Classes/Repository/ContentRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\Repository;
 
+use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -51,7 +52,7 @@ class ContentRepository
                 )
             )
             ->execute()
-            ->fetch();
+            ->{DoctrineDbalMethodNameHelper::fetchAssociative()}();
         if (!is_array($result)) {
             $result = [];
         }
@@ -85,7 +86,7 @@ class ContentRepository
                 )
             )
             ->execute()
-            ->fetchColumn(0);
+            ->{DoctrineDbalMethodNameHelper::fetchOne()}();
 
         /**
          * @var DeletedRestriction
@@ -106,7 +107,7 @@ class ContentRepository
                 )
             )
             ->execute()
-            ->fetchColumn(0);
+            ->{DoctrineDbalMethodNameHelper::fetchOne()}();
     }
 
     protected function generateQueryBuilder(string $table = ''): QueryBuilder

--- a/Classes/Repository/PagesRepository.php
+++ b/Classes/Repository/PagesRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\Repository;
 
+use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -69,7 +70,7 @@ class PagesRepository
             )
             ->execute();
 
-        while ($row = $result->fetch()) {
+        while ($row = $result->{DoctrineDbalMethodNameHelper::fetchAssociative()}()) {
             $id = (int)$row['uid'];
             $isHidden = (bool)$row['hidden'];
             $extendToSubpages = (bool)($row['extendToSubpages'] ?? 0);
@@ -212,7 +213,7 @@ class PagesRepository
             ->execute();
 
         $translatedPages = [];
-        while ($row = $result->fetch()) {
+        while ($row = $result->{DoctrineDbalMethodNameHelper::fetchAssociative()}()) {
             $translatedPages[] = (int)$row['uid'];
         }
 


### PR DESCRIPTION
There have been quite some changes between core v10 and v11, and used
doctrine/dbal versions with it's own transitions. Lately there were
some changes in the core facade classes, which now triggers phpstan
as calling old doctrine/methods on the new result interface fails as
there are no definitions anymore for the old methods like 'fetchColumn()',
'fetch()' or 'fetchAll()'.

Legacy installation of v10 ships a very old doctrine/dbal version without
support of the new methods, thus raising doctrine/dbal version as minimum
requirement would break support for v10 legacy installations.

To mitigate this, a small helper class is added to provide the corresponding
method named based on the installed core version, keeping full compatibility
about the whole version ranges but use the new methods on core v11 and avoid
the phpstand erros on it.

Furthermore, after raising minimum required coreversion to at least v11 this
class can vanish and the places simply replaced over the project.

This makes v11/composerInstallMax tests green and thus happy again.