### PR TITLE
[TASK] Set allowed composer plugins in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,11 @@
 	"config": {
 		"sort-packages": true,
 		"vendor-dir": ".Build/vendor",
-		"bin-dir": ".Build/bin"
+		"bin-dir": ".Build/bin",
+		"allow-plugins": {
+			"typo3/cms-composer-installers": true,
+			"typo3/class-alias-loader": true
+		}
 	},
 	"require": {
 		"php": "^7.2 || ^7.3 || ^7.4 || ^8.0 || ^8.1",


### PR DESCRIPTION
With composer >=2.2.0, allowed composer plugins have
to be added to composer.json as config/allowed_plugins.