### PR TITLE
[TASK] Streamline runTests.sh and docker-compose.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: "phpstan"
         if: ${{ always() && matrix.minMax == 'composerInstallMax' }}
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "-c ../Build/phpstan.neon"
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
 
       - name: "Unit tests"
         if: always()
@@ -108,7 +108,7 @@ jobs:
 
       - name: "phpstan"
         if: ${{ always() && matrix.minMax == 'composerInstallMax' }}
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "-c ../Build/phpstan.neon"
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
 
       - name: "Unit tests"
         if: always()

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -27,7 +27,6 @@ setUpDockerComposeDotEnv() {
         echo "HOST_HOME=${HOME}"
 
         # Your local user
-        echo "CORE_ROOT=${CORE_ROOT}"
         echo "CORE_VERSION=${CORE_VERSION}"
         echo "ROOT_DIR=${ROOT_DIR}"
         echo "HOST_USER=${USER}"
@@ -158,9 +157,13 @@ cd "$THIS_SCRIPT_DIR" || exit 1
 cd ../testing-docker || exit 1
 
 # Option defaults
-CORE_ROOT="${PWD}/../../"
+if ! command -v realpath &> /dev/null; then
+  echo "This script works best with realpath installed" >&2
+  ROOT_DIR="${PWD}/../../"
+else
+  ROOT_DIR=`realpath ${PWD}/../../`
+fi
 CORE_VERSION="10.4"
-ROOT_DIR=`readlink -f ${PWD}/../../`
 TEST_SUITE="unit"
 DBMS="mariadb"
 PHP_VERSION="7.2"

--- a/Build/phpstan.info.md
+++ b/Build/phpstan.info.md
@@ -5,15 +5,15 @@
 
 create:
 
-1. Increase level in phpstan.neon
-2. cd .Build; bin/phpstan analyze  --configuration ../Build/phpstan.neon ../Classes --generate-baseline
-3. cp phpstan.baseline.neon ../Build/phpstan-baseline-level$LEVEL.neon
+1. Increase level in `Build/phpstan.neon`
+2. `Build/Scripts/runTests.sh -s phpstan -e '--generate-baseline'`
+3. `cp phpstan.baseline.neon Build/phpstan-baseline-level$LEVEL.neon`
 
 # Dealing with mixed arrays
 
 Be as specific as possible, e.g. use
 
-* `array<string>` etc. 
+* `array<string>` etc.
 * or `array{'foo': int, "bar": string}`
 
 If the array is dynamic or cannot be specified, use `mixed[]`

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -6,20 +6,21 @@ includes:
   - ../.Build/vendor/jangregor/phpstan-prophecy/extension.neon
 
 parameters:
-  tmpDir: %currentWorkingDirectory%/var/cache/phpstan
+  # Use local cache dir instead of /tmp
+  tmpDir: ../.Build/.cache/phpstan
   parallel:
     # Don't be overly greedy on machines with more CPU's to be a good neighbor especially on CI
     maximumNumberOfProcesses: 5
   level: 6
   paths:
-    - %currentWorkingDirectory%/../Classes
-    - %currentWorkingDirectory%/../Tests
+    - %currentWorkingDirectory%/Classes
+    - %currentWorkingDirectory%/Tests
   scanDirectories:
-    - %currentWorkingDirectory%/Web/typo3/sysext
+    - %currentWorkingDirectory%/.Build/Web/typo3/sysext
 
   excludePaths:
-    - %currentWorkingDirectory%/../Classes/Hooks/DataHandlerHook.php
-    - %currentWorkingDirectory%/../Classes/Mail/GenerateCheckResultPlainMail.php
+    - %currentWorkingDirectory%/Classes/Hooks/DataHandlerHook.php
+    - %currentWorkingDirectory%/Classes/Mail/GenerateCheckResultPlainMail.php
 
   ignoreErrors:
     # https://phpstan.org/user-guide/ignoring-errors

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -31,10 +31,9 @@ services:
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
     command: >
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
@@ -47,10 +46,9 @@ services:
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
     command: >
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
@@ -63,10 +61,9 @@ services:
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
     command: >
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
@@ -90,10 +87,9 @@ services:
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
     command: >
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
@@ -117,10 +113,9 @@ services:
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
     command: >
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
@@ -136,9 +131,6 @@ services:
       - mariadb10
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     environment:
       typo3DatabaseName: func_test
       typo3DatabaseUsername: root
@@ -176,9 +168,6 @@ services:
       - mssql2019latest
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     environment:
       typo3DatabaseDriver: sqlsrv
       typo3DatabaseName: func
@@ -220,9 +209,6 @@ services:
       - postgres10
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     environment:
       typo3DatabaseDriver: pdo_pgsql
       typo3DatabaseName: bamboo
@@ -261,9 +247,6 @@ services:
       - ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     environment:
       typo3DatabaseDriver: pdo_sqlite
     working_dir: ${ROOT_DIR}/.Build
@@ -335,15 +318,16 @@ services:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
-      - ${CORE_ROOT}:${CORE_ROOT}
-    working_dir: ${ROOT_DIR}/.Build
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
     command: >
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
           set -x
         fi
-        mkdir -p .cache
-        bin/phpstan analyse --no-progress --no-interaction --memory-limit 4G ${EXTRA_TEST_OPTIONS} ${TEST_FILE}
+        mkdir -p .Build/.cache
+        php -v | grep '^PHP';
+        php -dxdebug.mode=off .Build/bin/phpstan analyse --no-progress --no-interaction --memory-limit 4G -c Build/phpstan.neon ${EXTRA_TEST_OPTIONS} ${TEST_FILE}
       "
 
   unit:
@@ -351,9 +335,6 @@ services:
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
-      - ${HOST_HOME}:${HOST_HOME}
-      - /etc/passwd:/etc/passwd:ro
-      - /etc/group:/etc/group:ro
     working_dir: ${ROOT_DIR}/.Build
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.2",
 		"jangregor/phpstan-prophecy": "^0.8.1 || ^1.0.0",
-		"phpstan/phpstan": "^1.2",
+		"phpstan/phpstan": "^1.4.3",
 		"phpunit/phpunit": "^8.5.21",
 		"typo3/testing-framework": "^6.15.1"
 	},


### PR DESCRIPTION
This patch streamlines the `Build/Scripts/runTests.sh`
setup and aligns corresponding `docker-compose.yml` to
incorporate recently changes added to `Typo3 Core` and
`ext:styleguide`.

* avoid `$HOME` directory volume mount from host to container
* avoid mounting `/etc/passwd` and `/etc/group` from host to container
* replace CORE_ROOT with ROOT_DIR in docker-compose.yml
* remove CORE_ROOT determination from 'Build/Scripts/runTests.sh'
* use `.Build/.cache` as `COMPOSER_CACHE_DIR`
* use `.Build/.cache/phpstan` as phpstan tmp folder
* use root folder as base for phpstan relative paths in configuration
  and adjust corresponding `working_dir` for docker container
* explicitly define `Build/phpstan.neon` as entrypoint for phpstan
  check with `Build/Scripts/runTests.sh -s phpstan`
* display phpversion on phpstan testsuit execution
* remove phpstan configuration file as parameter from git-workflow
* raise phpstan/phpstan to ^1.4.3"

used commands:

> composer req phpstan/phpstan:"^1.4.3" --dev