### PR TITLE
[TASK] Raise core versions "^10.4.24 || ^11.5.6"

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -6,69 +6,14 @@ parameters:
 			path: ../../Classes/CheckLinks/ExcludeLinkTarget.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 2
-			path: ../../Classes/CheckLinks/ExcludeLinkTarget.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 3
-			path: ../../Classes/CheckLinks/LinkTargetCache/LinkTargetPersistentCache.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 3
-			path: ../../Classes/CheckLinks/LinkTargetCache/LinkTargetPersistentCache.php
-
-		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 1
-			path: ../../Classes/CheckLinks/LinkTargetCache/LinkTargetPersistentCache.php
-
-		-
-			message: "#^Parameter \\#4 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 1
-			path: ../../Classes/CheckLinks/LinkTargetCache/LinkTargetPersistentCache.php
-
-		-
 			message: "#^Parameter \\#1 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
 			count: 6
-			path: ../../Classes/Repository/BrokenLinkRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 3
-			path: ../../Classes/Repository/BrokenLinkRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$where of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:andWhere\\(\\) expects array\\<int, string\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 4
 			path: ../../Classes/Repository/BrokenLinkRepository.php
 
 		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
 			count: 6
 			path: ../../Classes/Repository/BrokenLinkRepository.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 6
-			path: ../../Classes/Repository/BrokenLinkRepository.php
-
-		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 4
-			path: ../../Classes/Repository/BrokenLinkRepository.php
-
-		-
-			message: "#^Parameter \\#4 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 1
-			path: ../../Classes/Repository/BrokenLinkRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 3
-			path: ../../Classes/Repository/ContentRepository.php
 
 		-
 			message: "#^Parameter \\#1 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
@@ -79,24 +24,4 @@ parameters:
 			message: "#^Parameter \\#2 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
 			count: 1
 			path: ../../Classes/Repository/EditableRestriction.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 1
-			path: ../../Classes/Repository/ExcludeLinkTargetRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$where of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:andWhere\\(\\) expects array\\<int, string\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 4
-			path: ../../Classes/Repository/ExcludeLinkTargetRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 2
-			path: ../../Classes/Repository/PagesRepository.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$predicates of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder\\:\\:where\\(\\) expects array\\<int, mixed\\>\\|Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\CompositeExpression, string given\\.$#"
-			count: 1
-			path: ../../Classes/Repository/PagesRepository.php
 

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,10 @@
 	"require": {
 		"php": "^7.2 || ^7.3 || ^7.4 || ^8.0 || ^8.1",
 		"sypets/page-callouts": "^1.0.0 || ^2.0.0",
-		"typo3/cms-backend": "^10.4.21 || ^11.5.3",
-		"typo3/cms-core": "^10.4.21 || ^11.5.3",
-		"typo3/cms-fluid": "^10.4.21 || ^11.5.3",
-		"typo3/cms-info": "^10.4.21 || ^11.5.3"
+		"typo3/cms-backend": "^10.4.24 || ^11.5.6",
+		"typo3/cms-core": "^10.4.24 || ^11.5.6",
+		"typo3/cms-fluid": "^10.4.24 || ^11.5.6",
+		"typo3/cms-info": "^10.4.24 || ^11.5.6"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.2",
 		"jangregor/phpstan-prophecy": "^0.8.1 || ^1.0.0",
-		"phpstan/phpstan": "^1.4.3",
+		"phpstan/phpstan": "^1.4.5",
 		"phpunit/phpunit": "^8.5.21",
 		"typo3/testing-framework": "^6.15.1"
 	},


### PR DESCRIPTION
Raises core constraints to released versions and regenerate phpstan
baseline file, as corresponding bugfixes has been added and making
ignore patterns in the baseline file superflous now.

used commands:

```bash
$ composer req "typo3/cms-backend":"^10.4.24 || ^11.5.6" --no-update
$ composer req "typo3/cms-core":"^10.4.24 || ^11.5.6" --no-update
$ composer req "typo3/cms-fluid":"^10.4.24 || ^11.5.6" --no-update
$ composer req "typo3/cms-info":"^10.4.24 || ^11.5.6" --no-update
$ Build/Scripts/runTests.sh -s phpstanGenerateBaseline
```

and as second patch phpstan is raised:

```bash
$ composer req phpstan/phpstan:"^1.4.5" --dev --no-update
```