### PR TITLE
[TASK] Merge 2 lastcheck column into one

### DIFF
--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -14,6 +14,7 @@ use Sypets\Brofix\Linktype\ErrorParams;
 use Sypets\Brofix\Linktype\LinktypeInterface;
 use Sypets\Brofix\Repository\BrokenLinkRepository;
 use Sypets\Brofix\Repository\PagesRepository;
+use Sypets\Brofix\Util\StringUtil;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -60,16 +61,9 @@ class BrokenLinkListController extends AbstractBrofixController
             ['field', 'DESC'],
         ],
         'last_check' => [
-            ['last_check', 'ASC'],
-        ],
-        'last_check_reverse' => [
-            ['last_check', 'DESC'],
-        ],
-        // add by Mee
-        'last_check_url' => [
             ['last_check_url', 'ASC'],
         ],
-        'last_check_url_reverse' => [
+        'last_check_reverse' => [
             ['last_check_url', 'DESC'],
         ],
         'url' => [
@@ -655,10 +649,9 @@ class BrokenLinkListController extends AbstractBrofixController
             'page',
             'element',
             'type',
-            'last_check',
             'url',
             'error',
-            'last_check_url',
+            'last_check',
             'action'
         ];
 
@@ -886,15 +879,8 @@ class BrokenLinkListController extends AbstractBrofixController
         $variables['linktext'] = $hookObj->getBrokenLinkText($row, $errorParams->getCustom());
 
         // last check of record
-        $currentDate = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'], \time());
-        $lastcheckDate = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'], $row['last_check']);
-        $lastCheckTime = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'], $row['last_check']);
-        $variables['lastcheck'] = (($currentDate != $lastcheckDate) ? $lastcheckDate . ' ' : '') . $lastCheckTime;
-
-        // last check of URL
-        $lastcheckDateUrl = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'], $row['last_check_url']);
-        $lastCheckTimeUrl = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'], $row['last_check_url']);
-        $variables['lastcheck_url'] = (($currentDate != $lastcheckDateUrl) ? $lastcheckDateUrl . ' ' : '') . $lastCheckTimeUrl;
+        // show the oldest last_check, either for the record or for the link target
+        $variables['lastcheck'] = StringUtil::formatTimestampAsString($row['last_check'] < $row['last_check_url'] ? $row['last_check'] : $row['last_check_url']);
 
         // determine if check is fresh or stale
         $tstamp_field = $GLOBALS['TCA'][$row['table_name']]['ctrl']['tstamp'] ?? '';

--- a/Classes/Util/StringUtil.php
+++ b/Classes/Util/StringUtil.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sypets\Brofix\Util;
+
+class StringUtil
+{
+    /**
+     * Converts timestamp into date and time using defaults from
+     * $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'].
+     *
+     * If the date is today, only show time.
+     *
+     * @param int $timestamp
+     * @return string
+     */
+    public static function formatTimestampAsString(int $timestamp): string
+    {
+        $currentDate = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'], \time());
+        $date = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy'], $timestamp);
+        $time = date($GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm'], $timestamp);
+        return (($currentDate != $date) ? $date . ' ' : '') . $time;
+    }
+}

--- a/Resources/Private/Templates/Backend/BrokenLinkList.html
+++ b/Resources/Private/Templates/Backend/BrokenLinkList.html
@@ -129,12 +129,6 @@
 							<core:icon identifier="{tableHeader.type.icon}"/>
 						</f:if>
 					</th>
-					<th class="mobile-optional">
-						<f:format.raw>{tableHeader.last_check.header}</f:format.raw>
-						<f:if condition="{tableHeader.last_check.icon}">
-							<core:icon identifier="{tableHeader.last_check.icon}"/>
-						</f:if>
-					</th>
 					<th colspan="2">
 						<f:format.raw>{tableHeader.url.header}</f:format.raw>
 						<f:if condition="{tableHeader.url.icon}">
@@ -148,11 +142,11 @@
 						</f:if>
 					</th>
 					<th class="mobile-optional">
-						<f:format.raw> {tableHeader.last_check_url.header}</f:format.raw>
-						<f:if condition="{tableHeader.last_check_url.icon}">
-							<core:icon identifier="{tableHeader.last_check_url.icon}"/>
+						<f:format.raw> {tableHeader.last_check.header}</f:format.raw>
+						<f:if condition="{tableHeader.last_check.icon}">
+							<core:icon identifier="{tableHeader.last_check.icon}"/>
 						</f:if>
-						<br/>(URL)
+						<br/>
 					<th>
 						{tableHeader.action.header}
 					</th>
@@ -191,13 +185,7 @@
 						</div>
 					</td>
 					<td class="mobile-optional">{item.elementIcon -> f:format.raw()}<span
-						title="{item.table} {item.field}">{item.elementType}:<br/>{item.fieldName}</span></td>
-					<td class="mobile-optional"
-						title="{f:translate(key: 'list.info.freshness.{item.freshness}', extensionName: 'Brofix')}">
-						<span class="freshness_{item.freshness}">{item.lastcheck}</span>
-						<f:if condition="{item.freshness} == 'stale'>">
-							<core:icon identifier="actions-document-synchronize"/>
-						</f:if>
+						title="{item.table} {item.field}">{item.elementType}:<br/>{item.fieldName}</span>
 					</td>
 					<td colspan="2">
 						<f:if condition="{item.linktarget}">
@@ -222,7 +210,12 @@
 						</div>
 					</td>
 					<td>{item.linkmessage -> f:format.raw()}</td>
-					<td class="mobile-optional">{item.lastcheck_url}</td>
+					<td class="mobile-optional" title="{f:translate(key: 'list.info.freshness.{item.freshness}', extensionName: 'Brofix')}">
+						<span class="freshness_{item.freshness}">{item.lastcheck}</span>
+						<f:if condition="{item.freshness} == 'stale'>">
+							<core:icon identifier="actions-document-synchronize"/>
+						</f:if>
+					</td>
 					<td>
 						<a class="btn btn-primary" href="{item.editUrl}"
 						   title="{f:translate(key: 'list.edit.field', extensionName: 'Brofix')}">


### PR DESCRIPTION
There are 2 last check values stored in the database:

1. When the link target (URL) was last checked
2. When the element was last checked

Because of the (external) link target cache being used, these two values
may differ.

However showing both values, may be confusing and may offer little
additional values for the editors.

We now show the oldest of the 2 values, which will either be the
same for both values or most likely be the last checked time of the
link target.