### PR TITLE
[FEATURE] Add URL match selection

### DIFF
--- a/Classes/Controller/Filter/BrokenLinkListFilter.php
+++ b/Classes/Controller/Filter/BrokenLinkListFilter.php
@@ -22,6 +22,9 @@ class BrokenLinkListFilter
      */
     protected $url_filtre = '';
 
+    /** @var string  */
+    protected $urlFilterMatch = 'partial';
+
     /**
      * @var string
      * @deprecated
@@ -59,6 +62,22 @@ class BrokenLinkListFilter
     public function setUrlFilter(string $url_filter): void
     {
         $this->url_filtre = trim($url_filter);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrlFilterMatch(): string
+    {
+        return $this->urlFilterMatch;
+    }
+
+    /**
+     * @param string $urlFilterMatch
+     */
+    public function setUrlFilterMatch(string $urlFilterMatch): void
+    {
+        $this->urlFilterMatch = $urlFilterMatch;
     }
 
     /**

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -67,7 +67,19 @@
 				<source>URL</source>
 			</trans-unit>
 			<trans-unit id="list.filter.url.placeholder" resname="list.filter.url.placeholder">
-				<source>=URL (exact), URL (partial)</source>
+				<source>URL</source>
+			</trans-unit>
+			<trans-unit id="list.filter.url.match.partial" resname="list.filter.url.match.partial">
+				<source>partial match</source>
+			</trans-unit>
+			<trans-unit id="list.filter.url.match.exact" resname="list.filter.url.match.exact">
+				<source>exact match</source>
+			</trans-unit>
+			<trans-unit id="list.filter.url.match.partialnot" resname="list.filter.url.match.partialnot">
+				<source>no partial match</source>
+			</trans-unit>
+			<trans-unit id="list.filter.url.match.exactnot" resname="list.filter.url.match.exactnot">
+				<source>no exact match</source>
 			</trans-unit>
 			<trans-unit id="list.filter.title" resname="list.filter.title">
 				<source>Title</source>

--- a/Resources/Private/Templates/Backend/BrokenLinkList.html
+++ b/Resources/Private/Templates/Backend/BrokenLinkList.html
@@ -83,6 +83,20 @@
 							<core:icon identifier="actions-close" size="small" />
 						</button>
 					</div>
+					<select id="url_match_searchFilter" name="url_match_searchFilter" class="form-control tceforms-select">
+						<option value="partial" {f:if(condition:'{url_match_searchFilter} == partial', then: 'selected')}>
+							<f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.url.match.partial">partial match</f:translate>
+						</option>
+						<option value="exact" {f:if(condition:'{url_match_searchFilter} == exact', then: 'selected')}>
+							<f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.url.match.exact">exact match</f:translate>
+						</option>
+						<option value="partialnot" {f:if(condition:'{url_match_searchFilter} == partialnot', then: 'selected')}>
+							<f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.url.match.partialnot">no partial match</f:translate>
+						</option>
+						<option value="exactnot" {f:if(condition:'{url_match_searchFilter} == exactnot', then: 'selected')}>
+							<f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.url.match.exactnot">no exact match</f:translate>
+						</option>
+					</select>
 				</div>
 			</row>
 			<br/>
@@ -199,7 +213,7 @@
 						<div class="inline-action">
 							<f:if condition="{item.encoded_linktarget}">
 								<f:then>
-									<a href="{listUri}&url_searchFilter={item.encoded_linktarget}" title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.linktarget.tooltip', extensionName: 'Brofix')}">
+									<a href="{listUri}&url_searchFilter={item.encoded_linktarget}&url_match_searchFilter=exact" title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.linktarget.tooltip', extensionName: 'Brofix')}">
 										<f:translate key="filter" extensionName="Brofix">Filter</f:translate>
 									</a>
 								</f:then>

--- a/Resources/Public/JavaScript/Brofix.js
+++ b/Resources/Public/JavaScript/Brofix.js
@@ -19,10 +19,24 @@ define(['jquery'], function($) {
   'use strict';
   $(document).ready(function () {
 
+    // reload list on changing these values
     $('#linktype_searchFilter').on('change', function () {
       $('#refreshLinkList').click();
     })
 
+    $('#url_match_searchFilter').on('change', function () {
+      $('#refreshLinkList').click();
+    })
+
+    $('#view_table_complex').on('change', function () {
+      $('#refreshLinkList').click();
+    })
+
+    $('#view_table_min').on('change', function () {
+      $('#refreshLinkList').click();
+    })
+
+    // clear input text fields with X button
     $('#uidButton').on('click', function () {
       $('#uid_searchFilter').val('');
       $('#refreshLinkList').click();


### PR DESCRIPTION
It is now possible to select how to match the URL in a select box.

It is possible to select from the following:

- partial: This is a partial match of the URL (LIKE %url%)
- exact: The URL entered in the input field must match exactly
- no partial match: This is the opposite of partial match, all
  broken link records which do not match the URL via partial
  match are displayed
- no exact match: This is the opposite of the exact match, all
  broken link records which do not match the URL exactly are
  displayed.