### PR TITLE
Remove extra line break in module

### DIFF
--- a/Resources/Private/Templates/Backend/BrokenLinkList.html
+++ b/Resources/Private/Templates/Backend/BrokenLinkList.html
@@ -8,14 +8,12 @@
 </f:section>
 
 <f:section name="form">
-
 	<row class="brofix-brokenlink-list-form">
 		<form id="brofix-list-form" class="brofix-list-form">
 			<input type="hidden" name="currentPage" value="{currentPage}"/>
 			<input type="hidden" name="id" value="{currentPage}"/>
 			<input type="hidden" name="orderBy" value="{orderBy}"/>
 			<input type="hidden" name="paginationPage" value="{paginationPage}"/>
-			<br/>
 			<div class="form-group form-group-border">
 				<label for="brofix-list-select-pagedepth">
 					<f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:report.func.title"/>:


### PR DESCRIPTION
Remove extra line break which resulted in too much padding in the
top of the module.