### PR TITLE
Replace text for filter link target

### DIFF
--- a/Resources/Private/Templates/Backend/BrokenLinkList.html
+++ b/Resources/Private/Templates/Backend/BrokenLinkList.html
@@ -75,7 +75,7 @@
 					</f:if>
 
 				<div class="form-group form-group-border">
-					<label for="url_searchFilter"><f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.url"/>:</label>
+					<label for="url_searchFilter"><f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.tableHead.url"/>:</label>
 					<div class="form-control-clearable">
 						<input type="text" size="30" class="form-control t3js-clearable hasDefaultValue slug-impact t3js-charcounter-initialized" name="url_searchFilter" placeholder="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.url.placeholder')}" id="url_searchFilter" value="{url_filter}"/>
 						<button type="button" tabindex="-1" class="close" id="urlButton" style="visibility: visible;">


### PR DESCRIPTION
Use the same text (link target) for the text of the link target
which is also used as column header in the column we are
filtering. Otherwise, this is confusing.

The text for the column header was previously replaced.