### PR TITLE
Fix text inconsistencies

### DIFF
--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -617,12 +617,32 @@ class BrokenLinkListController extends AbstractBrofixController
      */
     protected function createFlashMessagesForNoBrokenLinks(): void
     {
+        $message = '';
+        $status = FlashMessage::OK;
+        if ($this->filter->hasConstraintsForNumberOfResults()) {
+            $status = FlashMessage::WARNING;
+            $message = $this->getLanguageService()->getLL('list.no.broken.links.filter')
+                ?: 'No broken links found if current filter is applied!';
+        } elseif ($this->depth === 0) {
+            $message = $this->getLanguageService()->getLL('list.no.broken.links.this.page')
+                ?: 'No broken links on this page!';
+            $message .= ' ' . $this->getLanguageService()->getLL('message.choose.higher.level');
+            $status = FlashMessage::INFO;
+        } elseif ($this->depth > 0 && $this->depth < BrokenLinkListFilter::PAGE_DEPTH_INFINITE) {
+            $message = $this->getLanguageService()->getLL('list.no.broken.links.current.level')
+                ?: 'No broken links for current level';
+            $message .= ' (' . $this->depth . ').';
+            $message .= ' ' . $this->getLanguageService()->getLL('message.choose.higher.level');
+            $status = FlashMessage::INFO;
+        } else {
+            $message = $this->getLanguageService()->getLL('list.no.broken.links.level.infinite')
+                ?: $this->getLanguageService()->getLL('list.no.broken.links')
+                ?: 'No broken links on this page and its subpages!';
+        }
         $this->createFlashMessage(
-            $this->getLanguageService()->getLL(
-                $this->depth > 0 ? 'list.no.broken.links' : 'list.no.broken.links.this.page'
-            ),
+            $message,
             '',
-            FlashMessage::OK
+            $status
         );
     }
 

--- a/Classes/Controller/Filter/BrokenLinkListFilter.php
+++ b/Classes/Controller/Filter/BrokenLinkListFilter.php
@@ -9,6 +9,12 @@ class BrokenLinkListFilter
     public const VIEW_MODE_MIN = 'view_table_min';
     public const VIEW_MODE_COMPLEX = 'view_table_complex';
 
+    /** @var string */
+    protected const LINK_TYPE_FILTER = 'all';
+
+    /** @var int */
+    public const PAGE_DEPTH_INFINITE = 999;
+
     /**
      * @var string
      */
@@ -33,6 +39,25 @@ class BrokenLinkListFilter
 
     /** @var string */
     protected $viewMode = self::VIEW_MODE_MIN;
+
+    /**
+     * Check if any filter is active
+     *
+     * - we do not include the View mode in this check since this will
+     *   no affect the number of results
+     *
+     * @return bool
+     */
+    public function hasConstraintsForNumberOfResults(): bool
+    {
+        if ($this->getUidFilter()
+            || $this->getLinktypeFilter() !== self::LINK_TYPE_FILTER
+            || $this->getUrlFilter()
+        ) {
+            return true;
+        }
+        return false;
+    }
 
     public function getUidFilter(): string
     {

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -102,6 +102,9 @@
 			<trans-unit id="list.filter.element.uid.tooltip" resname="list.filter.element.uid.tooltip">
 				<source>Show only broken links in this element</source>
 			</trans-unit>
+			<trans-unit id="list.filter.unset.tooltip" resname="list.filter.unset.tooltip">
+				<source>No longer apply this filter</source>
+			</trans-unit>
 			<trans-unit id="list.filter.view" resname="list.filter.view">
 				<source>View</source>
 			</trans-unit>
@@ -325,6 +328,9 @@
 			</trans-unit>
 			<trans-unit id="list.no.broken.links.this.page" resname="list.no.broken.links.this.page">
 				<source>No broken links on this page!</source>
+			</trans-unit>
+			<trans-unit id="list.no.broken.links.filter" resname="list.no.broken.links.filter">
+				<source>No broken links for current filter!</source>
 			</trans-unit>
 			<trans-unit id="no.access.title" resname="no.access.title">
 				<source>No access!</source>

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -326,11 +326,20 @@
 			<trans-unit id="list.no.broken.links" resname="list.no.broken.links">
 				<source>No broken links!</source>
 			</trans-unit>
+			<trans-unit id="list.no.broken.links.level.infinite" resname="list.no.broken.links.level.infinite">
+				<source>No broken links on this page and its subpages.</source>
+			</trans-unit>
 			<trans-unit id="list.no.broken.links.this.page" resname="list.no.broken.links.this.page">
 				<source>No broken links on this page!</source>
 			</trans-unit>
+			<trans-unit id="list.no.broken.links.current.level" resname="list.no.broken.links.current.level">
+				<source>No broken links for this level</source>
+			</trans-unit>
+			<trans-unit id="message.choose.higher.level" resname="message.choose.higher.level">
+				<source>You might see more results if you select a higher level.</source>
+			</trans-unit>
 			<trans-unit id="list.no.broken.links.filter" resname="list.no.broken.links.filter">
-				<source>No broken links for current filter!</source>
+				<source>No broken links found with current filter!</source>
 			</trans-unit>
 			<trans-unit id="no.access.title" resname="no.access.title">
 				<source>No access!</source>

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -97,10 +97,10 @@
 				<source>File</source>
 			</trans-unit>
 			<trans-unit id="list.filter.linktarget.tooltip" resname="list.filter.linktarget.tooltip">
-				<source>Show only results with this exact link target</source>
+				<source>Show only broken links with this exact link target</source>
 			</trans-unit>
 			<trans-unit id="list.filter.element.uid.tooltip" resname="list.filter.element.uid.tooltip">
-				<source>Show only broken links for this element</source>
+				<source>Show only broken links in this element</source>
 			</trans-unit>
 			<trans-unit id="list.filter.view" resname="list.filter.view">
 				<source>View</source>

--- a/Resources/Private/Templates/Backend/BrokenLinkList.html
+++ b/Resources/Private/Templates/Backend/BrokenLinkList.html
@@ -187,7 +187,9 @@
 						<div class="inline-action">
 							<f:if condition="{uid_filter}">
 								<f:then>
-									<a href="{listUri}&uid_searchFilter="><core:icon identifier="actions-close"/></a>
+									<a href="{listUri}&uid_searchFilter=" title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.unset.tooltip', extensionName: 'Brofix')}">
+										<core:icon identifier="actions-close"/>
+									</a>
 								</f:then>
 								<f:else>
 									<a href="{listUri}&uid_searchFilter={item.record_uid}" title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.element.uid.tooltip', extensionName: 'Brofix')}">
@@ -217,7 +219,9 @@
 									</a>
 								</f:then>
 								<f:else>
-									<a href="{listUri}&url_searchFilter="><core:icon identifier="actions-close"/></a>
+									<a href="{listUri}&url_searchFilter=" title="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.unset.tooltip', extensionName: 'Brofix')}">
+										<core:icon identifier="actions-close"/>
+									</a>
 								</f:else>
 							</f:if>
 						</div>


### PR DESCRIPTION
The tooltips for the filter are not fixed. Previously one of them
had the text "Show only results ..." and the other had "Show only
broken links ...". We now always use "Show broken links ...".