### PR TITLE
Optimize text for element filter

### DIFF
--- a/Resources/Private/Templates/Backend/BrokenLinkList.html
+++ b/Resources/Private/Templates/Backend/BrokenLinkList.html
@@ -51,9 +51,7 @@
 			<br/>
 			<row>
 				<div class="form-group form-group-border">
-					<label for="uid_searchFilter">
-						<f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.tableHead.element"/>&nbsp;
-						<f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.uid"/>:</label>
+					<label for="uid_searchFilter"><f:translate key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.tableHead.element"/>:</label>
 					<div class="form-control-clearable">
 						<input type="number" min="0" class="form-control t3js-clearable hasDefaultValue slug-impact t3js-charcounter-initialized" name="uid_searchFilter" placeholder="{f:translate(key: 'LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.uid')}" id="uid_searchFilter" value="{uid_filter}"/>
 						<button type="button" tabindex="-1" class="close" id="uidButton" style="visibility: visible;">


### PR DESCRIPTION
Use "Element" instead of "Element UID" as this is shorter and the
UID text is already used as placeholder.