### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+[![Latest Stable Version](https://poser.pugx.org/sypets/brofix/v/stable.svg)](https://extensions.typo3.org/extension/brofix/)
 [![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
 [![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg)](https://get.typo3.org/version/10)
+[![Total Downloads](https://poser.pugx.org/sypets/brofix/d/total.svg)](https://packagist.org/packages/sypets/brofix)
+[![Monthly Downloads](https://poser.pugx.org/sypets/brofix/d/monthly)](https://packagist.org/packages/sypets/brofix)
 [![Crowdin](https://badges.crowdin.net/typo3-extension-brofix/localized.svg)](https://crowdin.com/project/typo3-extension-brofix)
 [![CI Status](https://github.com/sypets/brofix/workflows/CI/badge.svg)](https://github.com/sypets/brofix/actions)
-[![Downloads](https://img.shields.io/packagist/dt/sypets/brofix)](https://packagist.org/packages/sypets/brofix)
 
 # TYPO3 extension `brofix`
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 			"role": "Developer"
 		}
 	],
+	"homepage": "https://extensions.typo3.org/extension/brofix",
 	"support": {
 		"docs": "https://docs.typo3.org/p/sypets/brofix/main/en-us/Index.html",
 		"issues": "https://github.com/sypets/brofix/issues",


### PR DESCRIPTION
Added two new commits regarding badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

Relates: TYPO3-Documentation/T3DocTeam#185