### PR TITLE
Fix phpstan warnings

### DIFF
--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -710,9 +710,9 @@ class BrokenLinkListController extends AbstractBrofixController
             if (isset($sortActions[$key])) {
                 // sorting available, add url
                 if ($this->orderBy === $key) {
-                    $tableHeadData[$key]['url'] = $sortActions[$key . '_reverse'] ?? '';
+                    $tableHeadData[$key]['url'] = $sortActions[$key . '_reverse'];
                 } else {
-                    $tableHeadData[$key]['url'] = $sortActions[$key] ?? '';
+                    $tableHeadData[$key]['url'] = $sortActions[$key];
                 }
 
                 // add icon only if this is the selected sort order

--- a/Classes/Controller/ManageExclusionsController.php
+++ b/Classes/Controller/ManageExclusionsController.php
@@ -340,9 +340,9 @@ class ManageExclusionsController extends AbstractBrofixController
             if (isset($sortActions[$key])) {
                 // sorting available, add url
                 if ($this->orderBy === $key) {
-                    $tableHeadData[$key]['url'] = $sortActions[$key . '_reverse'] ?? '';
+                    $tableHeadData[$key]['url'] = $sortActions[$key . '_reverse'];
                 } else {
-                    $tableHeadData[$key]['url'] = $sortActions[$key] ?? '';
+                    $tableHeadData[$key]['url'] = $sortActions[$key];
                 }
 
                 // add icon only if this is the selected sort order

--- a/Tests/Functional/AbstractFunctionalTest.php
+++ b/Tests/Functional/AbstractFunctionalTest.php
@@ -24,7 +24,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 abstract class AbstractFunctionalTest extends FunctionalTestCase
 {
     /**
-     * @var array<int,string>
+     * @var non-empty-string[]
      */
     protected $coreExtensionsToLoad = [
         'backend',
@@ -34,7 +34,7 @@ abstract class AbstractFunctionalTest extends FunctionalTestCase
     ];
 
     /**
-     * @var array<string>
+     * @var non-empty-string[]
      */
     protected $testExtensionsToLoad = [
         'typo3conf/ext/brofix',

--- a/Tests/Functional/CheckLinks/ExcludeLinkTargetTest.php
+++ b/Tests/Functional/CheckLinks/ExcludeLinkTargetTest.php
@@ -48,6 +48,11 @@ class ExcludeLinkTargetTest extends AbstractFunctionalTest
     /**
      * @test
      * @dataProvider isExcludedDataProvider
+     *
+     * @param non-empty-string $inputFile
+     * @param non-empty-string $url
+     * @param non-empty-string $linkType
+     * @param bool $expectedResult
      */
     public function isExcludedChecksUrlIsExcluded(string $inputFile, string $url, string $linkType, bool $expectedResult): void
     {

--- a/Tests/Functional/LinkAnalyzerTest.php
+++ b/Tests/Functional/LinkAnalyzerTest.php
@@ -86,7 +86,7 @@ class LinkAnalyzerTest extends AbstractFunctionalTest
      * @test
      * @dataProvider findAllBrokenLinksDataProvider
      *
-     * @param string $inputFile
+     * @param non-empty-string $inputFile
      * @param array<string|int> $pidList
      * @param string $expectedOutputFile
      * @throws \TYPO3\TestingFramework\Core\Exception
@@ -136,7 +136,7 @@ class LinkAnalyzerTest extends AbstractFunctionalTest
      * @test
      * @dataProvider findFindOnlyFileBrokenLinksDataProvider
      *
-     * @param string $inputFile
+     * @param non-empty-string $inputFile
      * @param array<string|int> $pidList
      * @param string $expectedOutputFile
      * @throws \TYPO3\TestingFramework\Core\Exception
@@ -189,7 +189,7 @@ class LinkAnalyzerTest extends AbstractFunctionalTest
      * @test
      * @dataProvider findFindOnlyPageBrokenLinksDataProvider
      *
-     * @param string $inputFile
+     * @param non-empty-string $inputFile
      * @param array<string|int> $pidList
      * @param string $expectedOutputFile
      *
@@ -243,7 +243,7 @@ class LinkAnalyzerTest extends AbstractFunctionalTest
      * @test
      * @dataProvider findFindOnlyExternalBrokenLinksDataProvider
      *
-     * @param string $inputFile
+     * @param non-empty-string $inputFile
      * @param array<string|int> $pidList
      * @param string $expectedOutputFile
      * @throws \TYPO3\TestingFramework\Core\Exception
@@ -295,7 +295,7 @@ class LinkAnalyzerTest extends AbstractFunctionalTest
      * @test
      * @dataProvider checkContentByTypeDataProvider
      *
-     * @param string $inputFile
+     * @param non-empty-string $inputFile
      * @param array<string|int> $pidList
      * @param string $expectedOutputFile
      *

--- a/Tests/Functional/Repository/BrokenLinkRepositoryTest.php
+++ b/Tests/Functional/Repository/BrokenLinkRepositoryTest.php
@@ -197,7 +197,7 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
 
     /**
      * @param array<mixed> $beuser
-     * @param string $inputFile
+     * @param non-empty-string $inputFile
      * @param array<int,int> $pidList
      * @param array<string,int> $expectedOutput
      * @throws \TYPO3\TestingFramework\Core\Exception
@@ -219,7 +219,7 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
         $linkTypes = ['db', 'file', 'external'];
         $this->configuration->setSearchFields($searchFields);
         $this->configuration->setLinkTypes($linkTypes);
-        $this->setupBackendUserAndGroup($beuser['uid'], $beuser['fixture'], $beuser['groupFixture']);
+        $this->setupBackendUserAndGroup($beuser['uid'], $beuser['fixture'], $beuser['groupFixture'] ?? '');
         $this->importDataSet($inputFile);
         $brokenLinksRepository = GeneralUtility::makeInstance(BrokenLinkRepository::class);
         $linkAnalyzer = GeneralUtility::makeInstance(LinkAnalyzer::class, $brokenLinksRepository);
@@ -325,7 +325,7 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
 
     /**
      * @param array<mixed> $beuser
-     * @param string $inputFile
+     * @param non-empty-string $inputFile
      * @param array<int,int> $pidList
      * @param int $expectedCount
      * @throws \TYPO3\TestingFramework\Core\Exception
@@ -613,7 +613,7 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
 
     /**
      * @param array<mixed> $beuser
-     * @param string $inputFile
+     * @param non-empty-string $inputFile
      * @param array<int,int> $pidList
      * @param array<string,mixed> $expectedResult
      * @throws \TYPO3\TestingFramework\Core\Exception
@@ -656,7 +656,12 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
         self::assertEquals($expectedResult, $results);
     }
 
-    protected function setupBackendUserAndGroup(int $uid, string $fixtureFile, string $groupFixtureFile): void
+    /**
+     * @param int $uid
+     * @param non-empty-string $fixtureFile
+     * @param string $groupFixtureFile
+     */
+    protected function setupBackendUserAndGroup(int $uid, string $fixtureFile, string $groupFixtureFile = ''): void
     {
         if ($groupFixtureFile) {
             $this->importDataSet($groupFixtureFile);

--- a/Tests/Functional/Repository/PagesRepositoryTest.php
+++ b/Tests/Functional/Repository/PagesRepositoryTest.php
@@ -149,7 +149,7 @@ class PagesRepositoryTest extends AbstractFunctionalTest
     }
 
     /**
-     * @param string $fixture
+     * @param non-empty-string $fixture
      * @param int $startPage
      * @param int $depth
      * @param string $permsClause

--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,10 @@
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.2",
-		"jangregor/phpstan-prophecy": "^0.8.1 || ^1.0.0",
-		"phpstan/phpstan": "^1.4.5",
+		"jangregor/phpstan-prophecy": "^1.0.0",
+		"phpstan/phpstan": "^1.7.2",
 		"phpunit/phpunit": "^8.5.21",
-		"typo3/testing-framework": "^6.15.1"
+		"typo3/testing-framework": "^6.16.5"
 	},
 	"suggest": {
 		"sypets/page-callouts": "^2.0.0"


### PR DESCRIPTION
Fixed some warnings due to changes in typo3/testing-framework and
phpstan.

Raised phpstan and testing-framework.

composer require typo3/testing-framework:^6.16.5
composer require phpstan/phpstan:^1.7.2