### PR TITLE
!!![TASK] Drop TYPO3 v10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,62 +13,6 @@ on:
 
 jobs:
 
-  all_core_10:
-    name: "all core-10"
-    runs-on: ubuntu-20.04
-    strategy:
-      # This prevents cancellation of matrix job runs, if one/two already failed and let the
-      # rest matrix jobs be be executed anyway.
-      fail-fast: false
-      matrix:
-        php: [ '7.2', '7.3', '7.4' ]
-        minMax: [ 'composerInstallMin', 'composerInstallMax' ]
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-
-      # This must be checked before core version select is run, as this would write this
-      # and than the check would fail - obiously.
-      - name: "Check if typo3/minimal has been pushed in composer.json"
-        run: Build/Scripts/checkComposerJsonForPushedMinimalPackage.sh
-
-      - name: "Set Typo3 core version"
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -t "^10.4" -s composerCoreVersion
-
-      - name: "Composer"
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s ${{ matrix.minMax }}
-
-      - name: "cgl"
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cgl -v -n
-
-      - name: "Composer validate"
-        if: always()
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
-
-      - name: "Lint PHP"
-        if: always()
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
-
-      - name: "phpstan"
-        if: ${{ always() && matrix.minMax == 'composerInstallMax' }}
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
-
-      - name: "Unit tests"
-        if: always()
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
-
-      - name: "Functional tests with mariadb"
-        if: always()
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
-
-      - name: "Functional tests with sqlite (nightly or pull_request)"
-        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
-
-      - name: "Functional tests with postgres (nightly or pull_request)"
-        if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'pull_request' ) }}
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
-
   all_core_11:
     name: "all core-11"
     runs-on: ubuntu-20.04

--- a/Build/Scripts/ci.sh
+++ b/Build/Scripts/ci.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
 
 # Convenience script to run CI tests locally
-# default: PHP 7.4 and composer latest (uses TYPO3 v11)
+# default: PHP 8.1 and composer latest (uses TYPO3 v11)
 
 # abort on error
 set -e
 set -x
 
-php="7.4"
-m="composerInstallMax"
-vt3="11"
+# --------
+# defaults
+# --------
+PHP_VERSION_DEFAULT="8.1"
+INSTALL_MIN_MAX_DEFAULT="composerInstallMax"
+TYPO3_VERSION_DEFAULT="11"
+
+
+# -------------
+# used settings
+# -------------
+# PHP version
+php=${PHP_VERSION_DEFAULT}
+# composerInstallMin | composerInstallMax
+m=${INSTALL_MIN_MAX_DEFAULT}
+# TYPO3 version
+vt3=${TYPO3_VERSION_DEFAULT}
 cleanup=0
 
 # -------------------
@@ -24,9 +38,9 @@ progname=$(basename $0)
 
 usage()
 {
-    echo "[-p <PHP version>] [-m <min|max>] [-t <10|11> [-h] [-c]"
+    echo "[-p <PHP version>] [-m <min|max>] [-t <11> [-h] [-c]"
     echo " -c : runs cleanup after"
-    echo " -t : TYPO3 version, can be 10 or 11, 11 is default"
+    echo " -t : TYPO3 version, ${PHP_VERSION_DEFAULT} is default"
     exit 1
 }
 
@@ -58,7 +72,8 @@ while getopts "hp:m:ct:" opt;do
 done
 shift $((OPTIND-1))
 
-echo "Running with PHP=$php and $m"
+echo "Running with PHP version${php} an TYPO3 version ${vt3} using ${m}"
+sleep 5
 
 # Run this in case we need test traits (see EXT:redirects_helper)
 #   we need to get typo3/cms-core as source to get the Tests dir with Test traits
@@ -66,10 +81,11 @@ echo "Running with PHP=$php and $m"
 # echo "Install typo3/cms-core as source. Modifies composer.json! (config:preferred-install)"
 # composer config preferred-install.typo3/cms-core source
 
-if [[ $vt3 == 10 ]];then
-    Build/Scripts/runTests.sh -p ${php} -t "^10.4" -s composerCoreVersion
-else
+if [[ $vt3 == 11 ]];then
     Build/Scripts/runTests.sh -p ${php} -t "^11.5" -s composerCoreVersion
+else
+    echo "wrong TYPO3 version"
+    exit 1
 fi
 
 echo "composer install"

--- a/Build/Scripts/cleanup.sh
+++ b/Build/Scripts/cleanup.sh
@@ -13,4 +13,5 @@ git diff composer.json
 echo "--------------------------------------------------------------------------------"
 
 rm -rf .Build
-rm composer.lock
+rm -f composer.lock
+rm -f Build/testing-docker/.env

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -75,9 +75,7 @@ Options:
     -t <composer-core-version-constraint>
         Only with -s composerCoreVersion
         Specifies the Typo3 core version to be used
-            - '^10.4' (default)
-            - '^11.5'
-            - '^11.5.3'
+            - '^11.5' (default)
             - ...
 
     -d <mariadb|mssql|postgres|sqlite>
@@ -130,17 +128,17 @@ Options:
         Show this help.
 
 Examples:
-    # Run unit tests using PHP 7.2
+    # Run unit tests using default PHP
     ./Build/Scripts/runTests.sh
 
-    # Run unit tests using PHP 7.3
-    ./Build/Scripts/runTests.sh -p 7.3
+    # Run unit tests using PHP 8.1
+    ./Build/Scripts/runTests.sh -p 8.1
 
-    # Run functional tests using PHP 7.4 and sqlite
-    ./Build/Scripts/runTests.sh -s functional -p 7.4 -d sqlite
+    # Run functional tests using sqlite
+    ./Build/Scripts/runTests.sh -s functional -d sqlite
 
-    # Run functional tests in phpunit with a filtered test method name in a specified file, php 7.4 and xdebug enabled.
-    ./Build/Scripts/runTests.sh -s functional -p 7.4 -x -e "--filter getLinkStatisticsFindOnlyPageBrokenLinks" Tests/Functional/LinkAnalyzerTest.php
+    # Run functional tests in phpunit with a filtered test method name in a specified file and xdebug enabled.
+    ./Build/Scripts/runTests.sh -s functional -x -e "--filter getLinkStatisticsFindOnlyPageBrokenLinks" Tests/Functional/LinkAnalyzerTest.php
 EOF
 
 # Test if docker-compose exists, else exit out with error
@@ -164,10 +162,10 @@ if ! command -v realpath &> /dev/null; then
 else
   ROOT_DIR=`realpath ${PWD}/../../`
 fi
-CORE_VERSION="10.4"
+CORE_VERSION="11.5"
 TEST_SUITE="unit"
 DBMS="mariadb"
-PHP_VERSION="7.2"
+PHP_VERSION="8.1"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 EXTRA_TEST_OPTIONS=""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ checked:
 5. functional tests
 
 For more information, see the file .github/workflows/tests.yml and
-the documentation on https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/Testing/ExtensionTesting.html.
+the documentation on https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Testing/ExtensionTesting.html.
 
 ### CGL
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
-[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg)](https://get.typo3.org/version/10)
 [![Crowdin](https://badges.crowdin.net/typo3-extension-brofix/localized.svg)](https://crowdin.com/project/typo3-extension-brofix)
 [![CI Status](https://github.com/sypets/brofix/workflows/CI/badge.svg)](https://github.com/sypets/brofix/actions)
 [![Downloads](https://img.shields.io/packagist/dt/sypets/brofix)](https://packagist.org/packages/sypets/brofix)

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
 		}
 	},
 	"require": {
-		"php": "^7.2 || ^7.3 || ^7.4 || ^8.0 || ^8.1",
-		"typo3/cms-backend": "^10.4.24 || ^11.5.6",
-		"typo3/cms-core": "^10.4.24 || ^11.5.6",
-		"typo3/cms-fluid": "^10.4.24 || ^11.5.6"
+		"php": "^7.4 || ^8.0 || ^8.1",
+		"typo3/cms-backend": "^11.5.10",
+		"typo3/cms-core": "^11.5.10",
+		"typo3/cms-fluid": "^11.5.10"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.2",
@@ -57,9 +57,6 @@
 			"extension-key": "brofix",
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",
 			"web-dir": ".Build/Web"
-		},
-		"branch-alias": {
-			"dev-master": "1.x-dev"
 		}
 	},
 	"autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,10 +11,10 @@ $EM_CONF[$_EXTKEY] = [
     'uploadfolder' => 0,
     'createDirs' => '',
     'clearCacheOnLoad' => 0,
-    'version' => '3.2.2',
+    'version' => '4.0.0-dev',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.14-11.9.99',
+            'typo3' => '11.5.10-11.9.99',
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
A branch typo3_10_dev has been created so that bugfixes can
be backported, but the main branch no longer supports TYPO3
v10. Dependencies and test scripts were modified accordingly.