### PR TITLE
[TASK] Align testing to TYPO3 v11 core constraints and changes

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,27 +1,3 @@
 parameters:
-	ignoreErrors:
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
-			count: 1
-			path: ../../Classes/CheckLinks/ExcludeLinkTarget.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
-			count: 6
-			path: ../../Classes/Repository/BrokenLinkRepository.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
-			count: 6
-			path: ../../Classes/Repository/BrokenLinkRepository.php
-
-		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
-			count: 4
-			path: ../../Classes/Repository/EditableRestriction.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$expressions of method TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) expects string, TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\Expression\\\\CompositeExpression given\\.$#"
-			count: 1
-			path: ../../Classes/Repository/EditableRestriction.php
+	ignoreErrors: []
 

--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -12,9 +12,10 @@
     TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
     file is located next to this .xml as FunctionalTestsBootstrap.php
 
-    @todo: Make phpunit v9 compatible, compare with core Build/phpunit/ version.
 -->
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     backupGlobals="true"
     bootstrap="FunctionalTestsBootstrap.php"
     cacheResult="false"
@@ -24,6 +25,7 @@
     convertDeprecationsToExceptions="true"
     convertNoticesToExceptions="true"
     forceCoversAnnotation="false"
+    processIsolation="false"
     stopOnError="false"
     stopOnFailure="false"
     stopOnIncomplete="false"
@@ -43,16 +45,18 @@
         </testsuite>
     </testsuites>
     <php>
-        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
-        <const name="TYPO3_MODE" value="BE" />
         <!--
             @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
                          with TYPO3 core v11 and up.
                          Will always be done with next major version.
                          To still suppress warnings, notices and deprecations, do NOT define the constant at all.
+            @todo Upgrade BrokenLinkRepository to incorporate core v11 changes and avoid deprecation messages, which
+                  are silenced away. Afterwards define following constant to find out which other places needs to be
+                  fixed and are silenced through error handler usage.
             <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true" />
          -->
         <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="E_ALL" />
         <env name="TYPO3_CONTEXT" value="Testing" />
     </php>
 </phpunit>

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -12,9 +12,10 @@
     TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
     file is located next to this .xml as FunctionalTestsBootstrap.php
 
-    @todo: Make phpunit v9 compatible, add the xml things to phpunit tag, see core versions.
 -->
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     backupGlobals="true"
     bootstrap="UnitTestsBootstrap.php"
     cacheResult="false"
@@ -43,20 +44,21 @@
             <directory>../../Tests/Unit/</directory>
         </testsuite>
     </testsuites>
-    <!-- @todo: change tag to 'coverage' when TF requires phpunit > 9 -->
-    <filter>
-        <!-- @todo: change tag to 'include' when TF requires phpunit > 9 -->
-        <whitelist>
+    <coverage>
+        <include>
             <!--
                 This path needs an adaption in extensions, when coverage statistics are wanted.
             -->
             <directory>../../Classes/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
     <php>
-        <!-- @deprecated: will be removed with next major version, constant TYPO3_MODE is deprecated -->
-        <const name="TYPO3_MODE" value="BE" />
         <ini name="display_errors" value="1" />
+        <!--
+            Set E_ALL after tests failing for E_ALL are fixed.
+        <ini name="error_reporting" value="E_ALL" />
+        -->
+        <ini name="error_reporting" value="E_ALL" />
         <env name="TYPO3_CONTEXT" value="Testing" />
     </php>
 </phpunit>

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -343,7 +343,7 @@ services:
         fi
         mkdir -p .Build/.cache
         php -v | grep '^PHP';
-        php -dxdebug.mode=off .Build/bin/phpstan analyse --no-progress --no-interaction --memory-limit 4G -c Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon ${EXTRA_TEST_OPTIONS}
+        php -dxdebug.mode=off .Build/bin/phpstan analyse --no-progress --no-interaction --memory-limit 4G -c Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon --allow-empty-baseline ${EXTRA_TEST_OPTIONS}
       "
 
   unit:

--- a/Classes/CheckLinks/ExcludeLinkTarget.php
+++ b/Classes/CheckLinks/ExcludeLinkTarget.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\CheckLinks;
 
-use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -65,7 +64,7 @@ class ExcludeLinkTarget
 
         $matchConstraints = [
             // match by: exact
-            $queryBuilder->expr()->andX(
+            $queryBuilder->expr()->and(
                 $queryBuilder->expr()->eq(
                     'linktarget',
                     $queryBuilder->createNamedParameter($url)
@@ -81,7 +80,7 @@ class ExcludeLinkTarget
         $parts = parse_url($url);
         if ($parts['host'] ?? false) {
             // match by: domain
-            $matchConstraints[] = $queryBuilder->expr()->andX(
+            $matchConstraints[] = $queryBuilder->expr()->and(
                 $queryBuilder->expr()->like(
                     'linktarget',
                     $queryBuilder->createNamedParameter($parts['host'])
@@ -94,7 +93,7 @@ class ExcludeLinkTarget
         }
         $constraints = [
             $queryBuilder->expr()->eq('link_type', $queryBuilder->createNamedParameter($linkType)),
-            $queryBuilder->expr()->orX(...$matchConstraints)
+            $queryBuilder->expr()->or(...$matchConstraints)
         ];
 
         if ($this->excludeLinkTargetsPid !== 0) {
@@ -110,8 +109,8 @@ class ExcludeLinkTarget
             ->where(
                 ...$constraints
             )
-            ->execute()
-            ->{DoctrineDbalMethodNameHelper::fetchOne()}());
+            ->executeQuery()
+            ->fetchOne());
         return $count > 0;
     }
 
@@ -137,8 +136,8 @@ class ExcludeLinkTarget
                         $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT)
                     )
                 )
-                ->execute()
-                ->{DoctrineDbalMethodNameHelper::fetchAssociative()}();
+                ->executeQuery()
+                ->fetchAssociative();
 
             return $GLOBALS['BE_USER']->doesUserHaveAccess($row, 16);
         }

--- a/Classes/CheckLinks/LinkTargetCache/LinkTargetPersistentCache.php
+++ b/Classes/CheckLinks/LinkTargetCache/LinkTargetPersistentCache.php
@@ -16,7 +16,6 @@ namespace Sypets\Brofix\CheckLinks\LinkTargetCache;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -57,12 +56,12 @@ class LinkTargetPersistentCache extends AbstractLinkTargetCache
             );
         }
 
-        return $queryBuilder
+        return (int)$queryBuilder
             ->count('uid')
             ->from(static::TABLE)
             ->where(...$constraints)
-            ->execute()
-            ->{DoctrineDbalMethodNameHelper::fetchOne()}() ? true : false;
+            ->executeQuery()
+            ->fetchOne() > 0;
     }
 
     /**
@@ -88,8 +87,8 @@ class LinkTargetPersistentCache extends AbstractLinkTargetCache
                 $queryBuilder->expr()->gt('last_check', $queryBuilder->createNamedParameter(\time()-$expire, \PDO::PARAM_INT))
             );
         $row = $queryBuilder
-            ->execute()
-            ->{DoctrineDbalMethodNameHelper::fetchAssociative()}();
+            ->executeQuery()
+            ->fetchAssociative();
         if (!$row) {
             return [];
         }
@@ -134,7 +133,7 @@ class LinkTargetPersistentCache extends AbstractLinkTargetCache
                     'last_check' => \time()
                 ]
             )
-            ->execute();
+            ->executeStatement();
     }
 
     /**
@@ -155,7 +154,7 @@ class LinkTargetPersistentCache extends AbstractLinkTargetCache
             ->set('url_response', \json_encode($urlResponse))
             ->set('check_status', (string)$checkStatus)
             ->set('last_check', (string)\time())
-            ->execute();
+            ->executeStatement();
     }
 
     public function remove(string $linkTarget, string $linkType): void
@@ -168,7 +167,7 @@ class LinkTargetPersistentCache extends AbstractLinkTargetCache
                 $queryBuilder->expr()->eq('url', $queryBuilder->createNamedParameter($linkTarget)),
                 $queryBuilder->expr()->eq('link_type', $queryBuilder->createNamedParameter($linkType))
             )
-            ->execute();
+            ->executeStatement();
     }
 
     protected function generateQueryBuilder(string $table = ''): QueryBuilder

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -378,14 +378,14 @@ class LinkAnalyzer implements LoggerAwareInterface
                 $record['record_uid'] = (int)$entryValue['uid'];
                 $record['table_name'] = $table;
                 $record['link_type'] = $key;
-                $record['link_title'] = $entryValue['link_title'];
+                $record['link_title'] = $entryValue['link_title'] ?? '';
                 $record['field'] = $entryValue['field'];
                 $typeField = $GLOBALS['TCA'][$table]['ctrl']['type'] ?? false;
                 if ($entryValue['row'][$typeField] ?? false) {
                     $record['element_type'] = $entryValue['row'][$typeField];
                 }
                 $record['exclude_link_targets_pid'] = $this->configuration->getExcludeLinkTargetStoragePid();
-                $pageWithAnchor = $entryValue['pageAndAnchor'];
+                $pageWithAnchor = $entryValue['pageAndAnchor'] ?? '';
                 if (!empty($pageWithAnchor)) {
                     // Page with anchor, e.g. 18#1580
                     $url = $pageWithAnchor;

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -1,7 +1,6 @@
 <?php
 
-// @todo
-//declare(strict_types=1);
+declare(strict_types=1);
 
 namespace Sypets\Brofix;
 
@@ -81,46 +80,26 @@ class LinkAnalyzer implements LoggerAwareInterface
      *
      * @var array<string|int>
      */
-    protected $pids = [];
+    protected array $pids = [];
 
     /**
      * Array for hooks for own checks
      *
      * @var \Sypets\Brofix\Linktype\AbstractLinktype[]
      */
-    protected $hookObjectsArr = [];
+    protected array $hookObjectsArr = [];
 
-    /**
-     * @var Configuration
-     */
-    protected $configuration;
-
-    /**
-     * @var BrokenLinkRepository
-     */
+    protected ?Configuration $configuration = null;
     protected BrokenLinkRepository  $brokenLinkRepository;
-
-    /**
-     * @var ContentRepository
-     */
-    protected $contentRepository;
-
-    /**
-     * @var PagesRepository
-     */
-    protected $pagesRepository;
-
-    /**
-     * @var FormDataCompiler
-     */
-    protected $formDataCompiler;
-
+    protected ContentRepository $contentRepository;
+    protected PagesRepository $pagesRepository;
+    protected FormDataCompiler $formDataCompiler;
     protected SoftReferenceParserFactory $softReferenceParserFactory;
 
     /**
-     * @var CheckLinksStatistics
+     * @var CheckLinksStatistics|null
      */
-    protected $statistics;
+    protected ?CheckLinksStatistics $statistics = null;
 
     /**
      * Fill hookObjectsArr with different link types and possible XClasses.

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -507,10 +507,8 @@ class LinkAnalyzer implements LoggerAwareInterface
                         ...$constraints
                     );
 
-                $result = $queryBuilder
-                    ->execute();
-
-                while ($row = $result->fetch()) {
+                $result = $queryBuilder->executeQuery();
+                while ($row = $result->fetchAssociative()) {
                     $results = [];
                     $l18nCfg = (int)($row['l18n_cfg'] ?? 0);
                     $languageField =  $GLOBALS['TCA'][$table]['ctrl']['languageField'] ?? '';

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -122,14 +122,14 @@ class LinkAnalyzer implements LoggerAwareInterface
      * Fill hookObjectsArr with different link types and possible XClasses.
      */
     public function __construct(
-        BrokenLinkRepository $brokenLinkRepository = null,
-        ContentRepository $contentRepository = null,
-        PagesRepository $pagesRepository = null
+        BrokenLinkRepository $brokenLinkRepository,
+        ContentRepository $contentRepository,
+        PagesRepository $pagesRepository
     ) {
         $this->getLanguageService()->includeLLFile('EXT:brofix/Resources/Private/Language/Module/locallang.xlf');
-        $this->brokenLinkRepository = $brokenLinkRepository ?: GeneralUtility::makeInstance(BrokenLinkRepository::class);
-        $this->contentRepository = $contentRepository ?: GeneralUtility::makeInstance(ContentRepository::class);
-        $this->pagesRepository = $pagesRepository ?: GeneralUtility::makeInstance(PagesRepository::class);
+        $this->brokenLinkRepository = $brokenLinkRepository;
+        $this->contentRepository = $contentRepository;
+        $this->pagesRepository = $pagesRepository;
 
         // Hook to handle own checks
         foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['brofix']['checkLinks'] ?? [] as $key => $className) {

--- a/Classes/Linktype/InternalLinktype.php
+++ b/Classes/Linktype/InternalLinktype.php
@@ -149,8 +149,8 @@ class InternalLinktype extends AbstractLinktype
                     $queryBuilder->createNamedParameter($pageUid, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
-            ->fetch();
+            ->executeQuery()
+            ->fetchAssociative();
 
         $customParams = [];
 
@@ -235,8 +235,8 @@ class InternalLinktype extends AbstractLinktype
                     $queryBuilder->createNamedParameter($contentUid, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
-            ->fetch();
+            ->executeQuery()
+            ->fetchAssociative();
         $this->responseContent = true;
 
         $customParams = [];

--- a/Classes/Repository/ContentRepository.php
+++ b/Classes/Repository/ContentRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\Repository;
 
-use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -51,8 +50,8 @@ class ContentRepository
                     $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
                 )
             )
-            ->execute()
-            ->{DoctrineDbalMethodNameHelper::fetchAssociative()}();
+            ->executeQuery()
+            ->fetchAssociative();
         if (!is_array($result)) {
             $result = [];
         }
@@ -85,8 +84,8 @@ class ContentRepository
                     $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
-            ->{DoctrineDbalMethodNameHelper::fetchOne()}();
+            ->executeQuery()
+            ->fetchOne();
 
         /**
          * @var DeletedRestriction
@@ -106,8 +105,8 @@ class ContentRepository
                     $queryBuilder->createNamedParameter($parentId, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
-            ->{DoctrineDbalMethodNameHelper::fetchOne()}();
+            ->executeQuery()
+            ->fetchOne();
     }
 
     protected function generateQueryBuilder(string $table = ''): QueryBuilder

--- a/Classes/Repository/EditableRestriction.php
+++ b/Classes/Repository/EditableRestriction.php
@@ -159,9 +159,9 @@ class EditableRestriction implements QueryRestrictionInterface
 
         if ($this->allowedFields) {
             $constraints = [
-                $expressionBuilder->orX(
+                $expressionBuilder->or(
                 // broken link is in page and page is editable
-                    $expressionBuilder->andX(
+                    $expressionBuilder->and(
                         $expressionBuilder->eq(
                             self::TABLE . '.table_name',
                             $this->queryBuilder->createNamedParameter('pages')
@@ -169,7 +169,7 @@ class EditableRestriction implements QueryRestrictionInterface
                         QueryHelper::stripLogicalOperatorPrefix($GLOBALS['BE_USER']->getPagePermsClause(Permission::PAGE_EDIT))
                     ),
                     // OR broken link is in content and content is editable
-                    $expressionBuilder->andX(
+                    $expressionBuilder->and(
                         $expressionBuilder->neq(
                             self::TABLE . '.table_name',
                             $this->queryBuilder->createNamedParameter('pages')
@@ -183,7 +183,7 @@ class EditableRestriction implements QueryRestrictionInterface
             $additionalWhere = [];
             foreach ($this->allowedFields as $table => $fields) {
                 foreach ($fields as $field => $value) {
-                    $additionalWhere[] = $expressionBuilder->andX(
+                    $additionalWhere[] = $expressionBuilder->and(
                         $expressionBuilder->eq(
                             self::TABLE . '.table_name',
                             $this->queryBuilder->createNamedParameter($table)
@@ -196,7 +196,7 @@ class EditableRestriction implements QueryRestrictionInterface
                 }
             }
             if ($additionalWhere) {
-                $constraints[] = $expressionBuilder->orX(...$additionalWhere);
+                $constraints[] = $expressionBuilder->or(...$additionalWhere);
             }
         } else {
             // add a constraint that will always return zero records because there are NO allowed fields
@@ -205,7 +205,7 @@ class EditableRestriction implements QueryRestrictionInterface
 
         foreach ($this->explicitAllowFields as $table => $field) {
             $additionalWhere = [];
-            $additionalWhere[] = $expressionBuilder->andX(
+            $additionalWhere[] = $expressionBuilder->and(
                 $expressionBuilder->eq(
                     self::TABLE . '.table_name',
                     $this->queryBuilder->createNamedParameter($table)
@@ -222,13 +222,13 @@ class EditableRestriction implements QueryRestrictionInterface
                 self::TABLE . '.table_name',
                 $this->queryBuilder->createNamedParameter($table)
             );
-            $constraints[] = $expressionBuilder->orX(...$additionalWhere);
+            $constraints[] = $expressionBuilder->or(...$additionalWhere);
         }
 
         if ($this->allowedLanguages) {
             $additionalWhere = [];
             foreach ($this->allowedLanguages as $langId) {
-                $additionalWhere[] = $expressionBuilder->orX(
+                $additionalWhere[] = $expressionBuilder->or(
                     $expressionBuilder->eq(
                         self::TABLE . '.language',
                         $this->queryBuilder->createNamedParameter($langId, \PDO::PARAM_INT)
@@ -239,10 +239,10 @@ class EditableRestriction implements QueryRestrictionInterface
                     )
                 );
             }
-            $constraints[] = $expressionBuilder->orX(...$additionalWhere);
+            $constraints[] = $expressionBuilder->or(...$additionalWhere);
         }
         // If allowed languages is empty: all languages are allowed, so no constraint in this case
 
-        return $expressionBuilder->andX(...$constraints);
+        return $expressionBuilder->and(...$constraints);
     }
 }

--- a/Classes/Repository/ExcludeLinkTargetRepository.php
+++ b/Classes/Repository/ExcludeLinkTargetRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sypets\Brofix\Repository;
 
 use Sypets\Brofix\Controller\Filter\ManageExclusionsFilter;
-use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -76,7 +75,7 @@ class ExcludeLinkTargetRepository
             }
         }
 
-        $results = array_merge($results, $queryBuilder->execute()->{DoctrineDbalMethodNameHelper::fetchAllAssociative()}());
+        $results = array_merge($results, $queryBuilder->executeQuery()->fetchAllAssociative());
         return $results;
     }
 
@@ -93,7 +92,7 @@ class ExcludeLinkTargetRepository
                 ->where(
                     $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT))
                 )
-                ->execute();
+                ->executeStatement();
         }
     }
 

--- a/Classes/Repository/PagesRepository.php
+++ b/Classes/Repository/PagesRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\Repository;
 
-use Sypets\Brofix\DoctrineDbalMethodNameHelper;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -90,9 +89,8 @@ class PagesRepository
                 )
             );
         }
-        $result = $queryBuilder->execute();
-
-        while ($row = $result->{DoctrineDbalMethodNameHelper::fetchAssociative()}()) {
+        $result = $queryBuilder->executeQuery();
+        while ($row = $result->fetchAssociative()) {
             $id = (int)$row['uid'];
             $isHidden = (bool)$row['hidden'];
             $extendToSubpages = (bool)($row['extendToSubpages'] ?? 0);
@@ -204,8 +202,8 @@ class PagesRepository
                     $queryBuilder->createNamedParameter($pageInfo['pid'], \PDO::PARAM_INT)
                 )
             )
-            ->execute()
-            ->fetch();
+            ->executeQuery()
+            ->fetchAssociative();
 
         if ($row !== false) {
             return $this->getRootLineIsHidden($row);
@@ -261,9 +259,9 @@ class PagesRepository
             ->select('uid', 'title', 'hidden')
             ->from(self::TABLE)
             ->where(...$constraints)
-            ->execute();
+            ->executeQuery();
 
-        while ($row = $result->{DoctrineDbalMethodNameHelper::fetchAssociative()}()) {
+        while ($row = $result->fetchAssociative()) {
             $id = (int)$row['uid'];
             $pageList[$id] = $id;
         }

--- a/Tests/Functional/Repository/BrokenLinkRepositoryTest.php
+++ b/Tests/Functional/Repository/BrokenLinkRepositoryTest.php
@@ -22,10 +22,11 @@ use Sypets\Brofix\LinkAnalyzer;
 use Sypets\Brofix\Repository\BrokenLinkRepository;
 use Sypets\Brofix\Tests\Functional\AbstractFunctionalTest;
 use TYPO3\CMS\Core\Core\Bootstrap;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class BrokenLinkRepositoryTest extends AbstractFunctionalTest
 {
+    protected ?BrokenLinkRepository $brokenLinkRepository = null;
+
     /**
      * @var array<string,array<mixed>>
      */
@@ -72,6 +73,7 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
         parent::setUp();
 
         $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'] = 'explicitAllow';
+        $this->brokenLinkRepository = new BrokenLinkRepository();
     }
 
     /**
@@ -221,14 +223,13 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
         $this->configuration->setLinkTypes($linkTypes);
         $this->setupBackendUserAndGroup($beuser['uid'], $beuser['fixture'], $beuser['groupFixture'] ?? '');
         $this->importDataSet($inputFile);
-        $brokenLinksRepository = GeneralUtility::makeInstance(BrokenLinkRepository::class);
-        $linkAnalyzer = GeneralUtility::makeInstance(LinkAnalyzer::class, $brokenLinksRepository);
+        $linkAnalyzer = $this->get(LinkAnalyzer::class);
         // @extensionScannerIgnoreLine
         $linkAnalyzer->init($pidList, $this->configuration);
         $linkAnalyzer->generateBrokenLinkRecords($linkTypes);
 
         // get result
-        $result = $brokenLinksRepository->getLinkCounts(
+        $result = $this->brokenLinkRepository->getLinkCounts(
             $pidList,
             $linkTypes,
             $searchFields
@@ -348,12 +349,11 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
         $this->configuration->setLinkTypes($linkTypes);
         $this->setupBackendUserAndGroup($beuser['uid'], $beuser['fixture'], $beuser['groupFixture']);
         $this->importDataSet($inputFile);
-        $brokenLinksRepository = GeneralUtility::makeInstance(BrokenLinkRepository::class);
-        $linkAnalyzer = GeneralUtility::makeInstance(LinkAnalyzer::class, $brokenLinksRepository);
+        $linkAnalyzer = $this->get(LinkAnalyzer::class);
         $linkAnalyzer->init($pidList, $this->configuration);
         $linkAnalyzer->generateBrokenLinkRecords($linkTypes);
 
-        $results = $brokenLinksRepository->getBrokenLinks(
+        $results = $this->brokenLinkRepository->getBrokenLinks(
             $pidList,
             $linkTypes,
             $searchFields,
@@ -637,13 +637,12 @@ class BrokenLinkRepositoryTest extends AbstractFunctionalTest
         $this->configuration->setLinkTypes($linkTypes);
         $this->setupBackendUserAndGroup($beuser['uid'], $beuser['fixture'], $beuser['groupFixture']);
         $this->importDataSet($inputFile);
-        $brokenLinksRepository = GeneralUtility::makeInstance(BrokenLinkRepository::class);
-        $linkAnalyzer = GeneralUtility::makeInstance(LinkAnalyzer::class, $brokenLinksRepository);
+        $linkAnalyzer = $this->get(LinkAnalyzer::class);
         $linkAnalyzer->init($pidList, $this->configuration);
         $linkAnalyzer->generateBrokenLinkRecords($linkTypes);
 
         // get results
-        $results = $brokenLinksRepository->getBrokenLinks(
+        $results = $this->brokenLinkRepository->getBrokenLinks(
             $pidList,
             $linkTypes,
             $searchFields,

--- a/Tests/Unit/AbstractUnitTest.php
+++ b/Tests/Unit/AbstractUnitTest.php
@@ -17,6 +17,7 @@ namespace Sypets\Brofix\Tests\Unit;
  */
 
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sypets\Brofix\Configuration\Configuration;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -25,6 +26,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 abstract class AbstractUnitTest extends UnitTestCase
 {
+    use ProphecyTrait;
 
     /**
      * @var Configuration

--- a/Tests/Unit/Linktype/ExternalLinktypePreprocessUrlTest.php
+++ b/Tests/Unit/Linktype/ExternalLinktypePreprocessUrlTest.php
@@ -16,6 +16,7 @@ namespace Sypets\Brofix\Tests\Unit\Linktype;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Prophecy\PhpUnit\ProphecyTrait;
 use Sypets\Brofix\CheckLinks\ExcludeLinkTarget;
 use Sypets\Brofix\CheckLinks\LinkTargetCache\LinkTargetPersistentCache;
 use Sypets\Brofix\Linktype\ExternalLinktype;
@@ -24,6 +25,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 class ExternalLinktypePreprocessUrlTest extends UnitTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @return \Generator<string,string[]>
      */

--- a/Tests/Unit/Linktype/ExternalLinktypeTest.php
+++ b/Tests/Unit/Linktype/ExternalLinktypeTest.php
@@ -19,6 +19,7 @@ namespace Sypets\Brofix\Tests\Unit\Linktype;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Response;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sypets\Brofix\CheckLinks\ExcludeLinkTarget;
 use Sypets\Brofix\CheckLinks\LinkTargetCache\LinkTargetPersistentCache;
@@ -29,6 +30,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ExternalLinktypeTest extends AbstractUnitTest
 {
+    use ProphecyTrait;
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,10 @@
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.2",
 		"jangregor/phpstan-prophecy": "^1.0.0",
+		"phpspec/prophecy": "^1.15.0",
+		"phpspec/prophecy-phpunit": "^2.0.1",
 		"phpstan/phpstan": "^1.7.2",
-		"phpunit/phpunit": "^8.5.21",
+		"phpunit/phpunit": "^9.5.20",
 		"typo3/testing-framework": "^6.16.5"
 	},
 	"suggest": {


### PR DESCRIPTION
This pull-requests contains multiplepatches. Main goal is
to align the testing to TYPO3 v11 core constraints, which
basically means to use phpunit v9 instead of phpunit v8.

Needed adjustments and solving @todo's in config files are
done to get a new minimum baseline testing after dropping
TYPO3 v10 support.

Additional @todo is added to functional testing configuration
file to activate proper constant to remove errorhandler which
hides away quite some errors, after e.g. `BrokenLinkRepository`
is modernized and incorporates latest changes in v11 regarding
deprecated softref parses (which throws silenced depreceration
error messages).

Additionally the pull-request contains a patch which change the
soft reference parsing to the new DI parsers to avoid deprecation
messages along with full DI usage for LinkAnalyzer constructor
services. This also includes an additional core fix, which fixes #99
along the way.

On top, a small bugfix to avoid "undefined array key access" errors
is included in the commit stack for this pull-request.

Also included is a patch avoiding deprecated doctrine/dbal methods
and using the new replacement methods along with the forward compatible
methods and replacements. This leads to an empty phpstan-baseline file
as it solves the remaining issues.

As last change, served with a cherry on top, `LinkAnalyzer` properties
get proper correct native types and class get's declared finally as
stricted typed.


Fixes #99 