### PR TITLE
[BUGFIX] Streamline session data

### DIFF
--- a/Classes/BackendSession/BackendSession.php
+++ b/Classes/BackendSession/BackendSession.php
@@ -15,10 +15,22 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\BackendSession;
 
+use __PHP_Incomplete_Class;
+use Sypets\Brofix\Controller\Filter\BrokenLinkListFilter;
+use Sypets\Brofix\Controller\Filter\ManageExclusionsFilter;
+use Sypets\Brofix\Util\Arrayable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 class BackendSession
 {
+    public const FILTER_KEY_LINKLIST = 'filterKey';
+    public const FILTER_KEY_MANAGE_EXCLUSIONS = 'filterKey_excludeLinks';
+
+    /** @var string[] */
+    protected $registeredKeys = [];
+
+    protected const STORAGE_KEY_DEFAULT = 'brofix_userData';
+
     /**
      * The backend session object
      *
@@ -26,35 +38,47 @@ class BackendSession
      */
     protected $sessionObject;
 
-    /**
-     * Unique key to store data in the session.
-     * Overwrite this key in your initializeAction method.
-     *
-     * @var string
-     */
-    protected $storageKey = 'filterKey';
-
     public function __construct()
     {
         $this->sessionObject = $GLOBALS['BE_USER'];
+        $this->registerFilterKey(self::FILTER_KEY_LINKLIST, BrokenLinkListFilter::class);
+        $this->registerFilterKey(self::FILTER_KEY_MANAGE_EXCLUSIONS, ManageExclusionsFilter::class);
     }
 
-    public function setStorageKey(string $storageKey): void
+    public function registerFilterKey(string $key, string $class): void
     {
-        $this->storageKey = $storageKey;
+        if (!$this->isClassImplementsInterface($class, Arrayable::class)) {
+            throw new \InvalidArgumentException('Given class not instance of Arrayable');
+        }
+        $this->registeredKeys[$key] = $class;
+    }
+
+    protected function isClassImplementsInterface(string $class, string $interface): bool
+    {
+        $interfaces = class_implements($class);
+        if ($interfaces && in_array($interface, $interfaces)) {
+            return true;
+        }
+        return false;
     }
 
     /**
-     * Store a value in the session
+     * Store a value in the session as array
+     *
+     * Prerequisite: the $key must have been registered previously via registerFilterKey
      *
      * @param string $key
-     * @param mixed $value
+     * @param Arrayable $value
      */
-    public function store(string $key, $value): void
+    public function store(string $key, Arrayable $value): void
     {
-        $sessionData = $this->sessionObject->getSessionData($this->storageKey);
-        $sessionData[$key] = $value;
-        $this->sessionObject->setAndSaveSessionData($this->storageKey, $sessionData);
+        if (!isset($this->registeredKeys[$key])) {
+            throw new \InvalidArgumentException('Unknown key ' . $key);
+        }
+        $valueArray = $value->toArray();
+        $sessionData = $this->sessionObject->getSessionData(self::STORAGE_KEY_DEFAULT);
+        $sessionData[$key] = $valueArray;
+        $this->sessionObject->setAndSaveSessionData(self::STORAGE_KEY_DEFAULT, $sessionData);
     }
 
     /**
@@ -64,20 +88,35 @@ class BackendSession
      */
     public function delete($key): void
     {
-        $sessionData = $this->sessionObject->getSessionData($this->storageKey);
+        $sessionData = $this->sessionObject->getSessionData(self::STORAGE_KEY_DEFAULT);
         unset($sessionData[$key]);
-        $this->sessionObject->setAndSaveSessionData($this->storageKey, $sessionData);
+        $this->sessionObject->setAndSaveSessionData(self::STORAGE_KEY_DEFAULT, $sessionData);
     }
 
     /**
-     * Read a value from the session
+     * Read a value from the session, convert array to object
      *
      * @param string $key
-     * @return mixed
+     * @return Arrayable
      */
-    public function get(string $key)
+    public function get(string $key): ?Arrayable
     {
-        $sessionData = $this->sessionObject->getSessionData($this->storageKey);
-        return isset($sessionData[$key]) ? $sessionData[$key] : null;
+        $sessionData = $this->sessionObject->getSessionData(self::STORAGE_KEY_DEFAULT);
+        if (!isset($sessionData[$key]) || !$sessionData[$key]) {
+            return null;
+        }
+        $result = $sessionData[$key];
+        // safeguard: check for incomplete class
+        if (is_object($result) && is_a($result, __PHP_Incomplete_Class::class)) {
+            $this->delete($key);
+            return null;
+        }
+        if (is_object($result) && is_a($result, Arrayable::class)) {
+            return $result;
+        }
+        if (is_array($result) && isset($this->registeredKeys[$key])) {
+            return call_user_func([$this->registeredKeys[$key], 'getInstanceFromArray'], $result);
+        }
+        return null;
     }
 }

--- a/Classes/Controller/Filter/BrokenLinkListFilter.php
+++ b/Classes/Controller/Filter/BrokenLinkListFilter.php
@@ -4,13 +4,28 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\Controller\Filter;
 
-class BrokenLinkListFilter
+use Sypets\Brofix\Util\Arrayable;
+
+class BrokenLinkListFilter implements Arrayable
 {
+    /** @var string  */
+    protected const KEY_UID = 'uid';
+    /** @var string */
+    protected const KEY_URL = 'url';
+    /** @var string */
+    protected const KEY_LINKTYPE = 'linktype';
+    /** @var string */
+    protected const KEY_URL_MATCH = 'urlMatch';
+
     public const VIEW_MODE_MIN = 'view_table_min';
     public const VIEW_MODE_COMPLEX = 'view_table_complex';
 
     /** @var string */
-    protected const LINK_TYPE_FILTER = 'all';
+    protected const LINK_TYPE_FILTER_DEFAULT = 'all';
+
+    protected const URL_MATCH_DEFAULT = 'partial';
+
+    protected const LINK_TYPE_DEFAULT = 'all';
 
     /** @var int */
     public const PAGE_DEPTH_INFINITE = 999;
@@ -21,7 +36,7 @@ class BrokenLinkListFilter
     protected $uid_filtre = '';
 
     /** @var string */
-    protected $linktype_filter = 'all';
+    protected $linktype_filter = self::LINK_TYPE_DEFAULT;
 
     /**
      * @var string
@@ -29,7 +44,7 @@ class BrokenLinkListFilter
     protected $url_filtre = '';
 
     /** @var string  */
-    protected $urlFilterMatch = 'partial';
+    protected $urlFilterMatch = self::URL_MATCH_DEFAULT;
 
     /**
      * @var string
@@ -39,6 +54,38 @@ class BrokenLinkListFilter
 
     /** @var string */
     protected $viewMode = self::VIEW_MODE_MIN;
+
+    public function __construct(
+        string $uid = '',
+        string $linkType = self::LINK_TYPE_DEFAULT,
+        string $url = '',
+        string $urlMatch = self::URL_MATCH_DEFAULT
+    ) {
+        $this->uid_filtre = $uid;
+        $this->linktype_filter = $linkType;
+        $this->url_filtre = $url;
+        $this->urlFilterMatch = $urlMatch;
+    }
+
+    public static function getInstanceFromArray(array $values): BrokenLinkListFilter
+    {
+        return new BrokenLinkListFilter(
+            $values[self::KEY_UID] ?? '',
+            $values[self::KEY_LINKTYPE] ?? self::LINK_TYPE_DEFAULT,
+            $values[self::KEY_URL] ?? '',
+            $values[self::KEY_URL_MATCH] ?? self::URL_MATCH_DEFAULT
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            self::KEY_UID => $this->getUidFilter(),
+            self::KEY_LINKTYPE => $this->getLinktypeFilter(),
+            self::KEY_URL => $this->getUrlFilter(),
+            self::KEY_URL_MATCH => $this->getUrlFilterMatch(),
+        ];
+    }
 
     /**
      * Check if any filter is active
@@ -51,7 +98,7 @@ class BrokenLinkListFilter
     public function hasConstraintsForNumberOfResults(): bool
     {
         if ($this->getUidFilter()
-            || $this->getLinktypeFilter() !== self::LINK_TYPE_FILTER
+            || $this->getLinktypeFilter() !== self::LINK_TYPE_FILTER_DEFAULT
             || $this->getUrlFilter()
         ) {
             return true;

--- a/Classes/Controller/Filter/ManageExclusionsFilter.php
+++ b/Classes/Controller/Filter/ManageExclusionsFilter.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Sypets\Brofix\Controller\Filter;
 
-class ManageExclusionsFilter
+use Sypets\Brofix\Util\Arrayable;
+
+class ManageExclusionsFilter implements Arrayable
 {
+    protected const KEY_LINKTYPE = 'linkType';
+    protected const KEY_URL = 'url';
+    protected const KEY_REASON = 'reason';
+    protected const KEY_STORAGE_PID = 'storagePid';
+
     /**
      * @var string
      */
@@ -25,6 +32,43 @@ class ManageExclusionsFilter
      * @var int
      */
     protected $excludeStoragePid;
+
+    public function __construct(string $linkType = '', string $url = '', string $reason = '', int $storagePid = 0)
+    {
+        $this->setExcludeLinkTypeFilter($linkType);
+        $this->setExcludeUrlFilter($url);
+        $this->setExcludeReasonFilter($reason);
+        $this->setExcludeStoragePid($storagePid);
+    }
+
+    /**
+     * @param array<mixed> $values
+     * @return ManageExclusionsFilter
+     */
+    public static function getInstanceFromArray(array $values): ManageExclusionsFilter
+    {
+        return new ManageExclusionsFilter(
+            $values[self::KEY_LINKTYPE] ?? '',
+            $values[self::KEY_URL] ?? '',
+            $values[self::KEY_REASON] ?? '',
+            $values[self::KEY_STORAGE_PID] ?? '',
+        );
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<mixed>
+     */
+    public function toArray()
+    {
+        return [
+            self::KEY_LINKTYPE => $this->getExcludeLinkTypeFilter(),
+            self::KEY_URL => $this->getExcludeUrlFilter(),
+            self::KEY_REASON => $this->getExcludeReasonFilter(),
+            self::KEY_STORAGE_PID => $this->getExcludeStoragePid(),
+        ];
+    }
 
     // Getters and Setters
 

--- a/Classes/Controller/ManageExclusionsController.php
+++ b/Classes/Controller/ManageExclusionsController.php
@@ -238,12 +238,11 @@ class ManageExclusionsController extends AbstractBrofixController
 
         // to prevent deleting session, when user sort the records
         if (!is_null(GeneralUtility::_GP('excludeLinkType_filter')) || !is_null(GeneralUtility::_GP('excludeUrl_filter')) || !is_null(GeneralUtility::_GP('excludeReason_filter'))) {
-            $this->backendSession->store('filterKey_excludeLinks', $this->filter);
+            $this->backendSession->store(BackendSession::FILTER_KEY_MANAGE_EXCLUSIONS, $this->filter);
         }
         // create session, if it the first time
-        if (is_null($this->backendSession->get('filterKey_excludeLinks'))) {
-            $this->backendSession->setStorageKey('filterKey_excludeLinks');
-            $this->backendSession->store('filterKey_excludeLinks', new ManageExclusionsFilter());
+        if (is_null($this->backendSession->get(BackendSession::FILTER_KEY_MANAGE_EXCLUSIONS))) {
+            $this->backendSession->store(BackendSession::FILTER_KEY_MANAGE_EXCLUSIONS, new ManageExclusionsFilter());
         }
     }
 
@@ -254,10 +253,12 @@ class ManageExclusionsController extends AbstractBrofixController
     {
         $items = [];
         // build the search filter from the backendSession session
-        $searchFilter = new ManageExclusionsFilter();
-        $searchFilter->setExcludeUrlFilter($this->backendSession->get('filterKey_excludeLinks')->getExcludeUrlFilter());
-        $searchFilter->setExcludeLinkTypeFilter($this->backendSession->get('filterKey_excludeLinks')->getExcludeLinkTypeFilter());
-        $searchFilter->setExcludeReasonFilter($this->backendSession->get('filterKey_excludeLinks')->getExcludeReasonFilter());
+        $arrayable = $this->backendSession->get(BackendSession::FILTER_KEY_MANAGE_EXCLUSIONS);
+        if ($arrayable) {
+            $searchFilter = ManageExclusionsFilter::getInstanceFromArray($arrayable->toArray());
+        } else {
+            $searchFilter = new ManageExclusionsFilter();
+        }
         $searchFilter->setExcludeStoragePid($this->storagePid);
 
         // Get Records from the database
@@ -306,9 +307,15 @@ class ManageExclusionsController extends AbstractBrofixController
         $this->view->assign('sortActions', $sortActions);
         $this->view->assign('tableHeader', $this->getVariablesForTableHeader($sortActions));
         // assign the filters value in the inputs
-        $this->view->assign('excludeUrl_filter', $this->backendSession->get('filterKey_excludeLinks')->getExcludeUrlFilter());
-        $this->view->assign('excludeLinkType_filter', $this->backendSession->get('filterKey_excludeLinks')->getExcludeLinkTypeFilter());
-        $this->view->assign('excludeReason_filter', $this->backendSession->get('filterKey_excludeLinks')->getExcludeReasonFilter());
+        $arrayable = $this->backendSession->get(BackendSession::FILTER_KEY_MANAGE_EXCLUSIONS);
+        if ($arrayable) {
+            $searchFilter = ManageExclusionsFilter::getInstanceFromArray($arrayable->toArray());
+        } else {
+            $searchFilter = new ManageExclusionsFilter();
+        }
+        $this->view->assign('excludeUrl_filter', $searchFilter->getExcludeUrlFilter());
+        $this->view->assign('excludeLinkType_filter', $searchFilter->getExcludeLinkTypeFilter());
+        $this->view->assign('excludeReason_filter', $searchFilter->getExcludeReasonFilter());
     }
 
     /**

--- a/Classes/Repository/ExcludeLinkTargetRepository.php
+++ b/Classes/Repository/ExcludeLinkTargetRepository.php
@@ -30,27 +30,26 @@ class ExcludeLinkTargetRepository
 
         $queryBuilder
             ->select(self::TABLE . '.*')
-            ->from(self::TABLE)
-            ->join(
-                self::TABLE,
-                'pages',
-                'pages',
-                // @todo record_pid is not always page id
-                $queryBuilder->expr()->eq(self::TABLE . '.pid', $queryBuilder->quoteIdentifier('pages.uid'))
-            )
+            ->from(self::TABLE);
+        $urlFilter = $filter->getExcludeUrlFilter();
+        if ($urlFilter) {
             // SQL Filter
-            ->andWhere(
+            $queryBuilder->andWhere(
                 $queryBuilder->expr()->like(
                     self::TABLE . '.linktarget',
-                    $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($filter->getExcludeUrlFilter()) . '%')
-                )
-            )
-            ->andWhere(
-                $queryBuilder->expr()->like(
-                    self::TABLE . '.link_type',
-                    $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($filter->getExcludeLinkTypeFilter()) . '%')
+                    $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($urlFilter) . '%')
                 )
             );
+        }
+        $linktypeFilter = $filter->getExcludeLinkTypeFilter();
+        if ($linktypeFilter) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->like(
+                    self::TABLE . '.link_type',
+                    $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($linktypeFilter) . '%')
+                )
+            );
+        }
         $storagePid = $filter->getExcludeStoragePid();
         if ($storagePid !== -1) {
             $queryBuilder->andWhere(

--- a/Classes/Util/Arrayable.php
+++ b/Classes/Util/Arrayable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+namespace Sypets\Brofix\Util;
+
+interface Arrayable
+{
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<mixed>
+     */
+    public function toArray();
+
+    /**
+     * @param array<mixed> $values
+     * @return mixed
+     */
+    public static function getInstanceFromArray(array $values);
+}


### PR DESCRIPTION
Session data will be passed as array. Use generic interface to
handle conversions.

This also fixes a possible exception with incomplete objects
being returned as session data.


Resolves: #208
Releases: main