### PR TITLE
[TASK] Use phpstan github error format in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: "phpstan"
         if: ${{ always() && matrix.minMax == 'composerInstallMax' }}
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "--error-format=github"
 
       - name: "Unit tests"
         if: always()

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -94,7 +94,7 @@ Options:
             - 8.0: use PHP 8.0
             - 8.1: use PHP 8.1
 
-    -e "<phpunit options>"
+    -e "<phpunit|phpstan options>"
         Only with -s functional|unit|phpstan
         Additional options to send to phpunit tests.
         For phpunit, options starting with "--" must be added after options starting with "-".


### PR DESCRIPTION
Use specific `github error formatting` for `phpstan`
error reporing in `github actions`. This adds the
phpstan errors directly into the file view on pull
requests for better readability.

![Auswahl_916](https://user-images.githubusercontent.com/1453466/181031078-88ae6bd1-1659-4ddd-a3a6-aef5f2426299.png)

For direct pushes
on commit level it directly extracts and shows the
errors in the pane instead of only in the command
line view.

![Auswahl_917](https://user-images.githubusercontent.com/1453466/181031161-ead377ab-3941-4cf0-8397-857952a5e059.png)

> **Note:** images are not from this repo, so do not be confused with stated filenames.
