### PR TITLE
Fix uninitialized array key when accessing user settings

### DIFF
--- a/Classes/Controller/UiHelper/UserSettings.php
+++ b/Classes/Controller/UiHelper/UserSettings.php
@@ -40,7 +40,7 @@ class UserSettings
      */
     public static function initializeFromSettingsAndGetParameters(array $modSettings): UserSettings
     {
-        $viewMode = $modSettings[self::KEY_VIEW_MODE] ?: '';
+        $viewMode = $modSettings[self::KEY_VIEW_MODE] ?? '';
         if (GeneralUtility::_GP('view_mode')) {
             $viewMode = GeneralUtility::_GP('view_mode');
         }


### PR DESCRIPTION
Fix problem of uninitialized array key with PHP 8.1