### PR TITLE
[TASK] Remove "cms-package-dir" from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
 	"extra": {
 		"typo3/cms": {
 			"extension-key": "brofix",
-			"cms-package-dir": "{$vendor-dir}/typo3/cms",
 			"web-dir": ".Build/Web"
 		}
 	},


### PR DESCRIPTION
This is no longer being used by the composer installers and should be removed.