### PR TITLE
[TASK] Execute scheduled CI workflow only in main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
 jobs:
 
   all_core_11:
+    # only run jobs via scheduled workflow in main repo, not in forks
+    if: (github.event_name == 'schedule' && github.repository == 'sypets/brofix') || (github.event_name != 'schedule')
     name: "all core-11"
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
We do not want the scheduled workflow to run in every fork of this repository because it is only necessary to run it once in the main repo.