### PR TITLE
[TASK] Fix deprecated php-cs-fixer configuration

### DIFF
--- a/Build/.php-cs-fixer.php
+++ b/Build/.php-cs-fixer.php
@@ -80,7 +80,7 @@ $config
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_superfluous_elseif' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,


### PR DESCRIPTION
- Rule "no_trailing_comma_in_singleline_array" is deprecated. Use "no_trailing_comma_in_singleline" instead.