### PR TITLE
[BUGFIX] TypeError on trim() when TCA label points to "uid" (PHP 8)

### DIFF
--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -358,7 +358,7 @@ class LinkAnalyzer implements LoggerAwareInterface
                     $row['uid'],
                     false
                 );
-                $headline = trim($headline);
+                $headline = trim((string)$headline);
 
                 $record['headline'] = $headline;
 


### PR DESCRIPTION
When checking custom tables which have a TCA setup of `['ctrl']['label'] = 'uid'` with PHP 8 you end up with an TypeError (aborting the whole process):

`trim(): Argument #1 ($string) must be of type string, int given`

The reason is that `BackendUtility::getProcessedValue` returns the integer, despite it's phpdoc stating `@return string|null`.

So casting it to a string is the easiest solution, which would also cope with a potential "null" headline being returned.

Resolves #277 