### PR TITLE
[BUGFIX] Fix checking page links with anchors (#286) - v12 / main

### DIFF
--- a/Classes/Linktype/InternalLinktype.php
+++ b/Classes/Linktype/InternalLinktype.php
@@ -109,7 +109,7 @@ class InternalLinktype extends AbstractLinktype
             if ($parsedTypoLinkUrl['host'] === 'page') {
                 parse_str($parsedTypoLinkUrl['query'], $query);
                 if (isset($query['uid'])) {
-                    $page = (int)$query['uid'];
+                    $pageUid = (int)$query['uid'];
                     $contentUid = (int)$url;
                 }
             }

--- a/Tests/Functional/Fixtures/input_content_with_not_broken_page_link_with_anchor.xml
+++ b/Tests/Functional/Fixtures/input_content_with_not_broken_page_link_with_anchor.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <doktype>0</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <doktype>0</doktype>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <bodytext>&lt;p&gt;&lt;a href=&quot;t3://page?uid=2#2&quot;&gt;not broken link&lt;/a&gt;&lt;/p&gt;</bodytext>
+        <CType>textmedia</CType>
+        <colPos>0</colPos>
+    </tt_content>
+    <tt_content>
+        <uid>2</uid>
+        <pid>2</pid>
+        <bodytext>&lt;p&gt;hello&lt;/p&gt;</bodytext>
+        <CType>textmedia</CType>
+        <colPos>0</colPos>
+    </tt_content>
+</dataset>

--- a/Tests/Functional/Fixtures/input_content_with_not_broken_page_link_with_anchor_in_header_link.xml
+++ b/Tests/Functional/Fixtures/input_content_with_not_broken_page_link_with_anchor_in_header_link.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <doktype>0</doktype>
+    </pages>
+    <pages>
+        <uid>2</uid>
+        <pid>1</pid>
+        <doktype>0</doktype>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <header>header with link</header>
+        <header_link>t3://page?uid=2#2</header_link>
+        <CType>textmedia</CType>
+        <colPos>0</colPos>
+    </tt_content>
+    <tt_content>
+        <uid>2</uid>
+        <pid>2</pid>
+        <bodytext>&lt;p&gt;hello&lt;/p&gt;</bodytext>
+        <CType>textmedia</CType>
+        <colPos>0</colPos>
+    </tt_content>
+</dataset>

--- a/Tests/Functional/LinkAnalyzerTest.php
+++ b/Tests/Functional/LinkAnalyzerTest.php
@@ -289,13 +289,24 @@ class LinkAnalyzerTest extends AbstractFunctional
         $pidList1 = [1];
 
         return [
-            // Tests with one broken link
             'Test with one not broken page link' =>
                 [
                     __DIR__ . '/Fixtures/input_content_with_not_broken_page_link.xml',
-                    [1],
+                    $pidList1,
                     'EXT:brofix/Tests/Functional/Fixtures/expected_output_content_with_not_broken_page_link.csv'
-                ]
+                ],
+            'Test with one not broken page link with anchor' =>
+                [
+                    __DIR__ . '/Fixtures/input_content_with_not_broken_page_link_with_anchor.xml',
+                    $pidList1,
+                    'EXT:brofix/Tests/Functional/Fixtures/expected_output_content_with_not_broken_page_link.csv'
+                ],
+            'Test with one not broken page link with anchor in header_link' =>
+                [
+                    __DIR__ . '/Fixtures/input_content_with_not_broken_page_link_with_anchor_in_header_link.xml',
+                    $pidList1,
+                    'EXT:brofix/Tests/Functional/Fixtures/expected_output_content_with_not_broken_page_link.csv'
+                ],
         ];
     }
 


### PR DESCRIPTION
Links to pages with anchor (e.g. "t3://page?uid=1#22") in non-RTE fields (e.g. tt_content.header_link) were falsely detected as broken. This is now fixed.

Additionally, functional tests were added to cover this in the future.

Resolves: #284
Releases: main, 11.5