### PR TITLE
Make it possible to use regex in crawlDelay.nodelay

### DIFF
--- a/Classes/CheckLinks/CrawlDelay.php
+++ b/Classes/CheckLinks/CrawlDelay.php
@@ -25,11 +25,6 @@ use Sypets\Brofix\Configuration\Configuration;
 class CrawlDelay
 {
     /**
-     * @var int
-     */
-    protected $delaySeconds;
-
-    /**
      * @var array<string>
      */
     protected $noCrawlDelayDomains;
@@ -41,10 +36,11 @@ class CrawlDelay
      */
     protected $lastCheckedDomainTimestamps = [];
 
+    protected Configuration $configuration;
+
     public function setConfiguration(Configuration $config): void
     {
-        $this->delaySeconds = $config->getCrawlDelaySeconds();
-        $this->noCrawlDelayDomains = $config->getCrawlDelayNodelay();
+        $this->configuration = $config;
     }
 
     /**
@@ -56,8 +52,8 @@ class CrawlDelay
      */
     public function crawlDelay(string $domain): int
     {
-        if ($domain === '' || in_array($domain, $this->noCrawlDelayDomains)) {
-            // skip delay
+        $delaySeconds = $this->getCrawlDelayByDomain($domain);
+        if ($delaySeconds === 0) {
             return 0;
         }
         /**
@@ -67,7 +63,7 @@ class CrawlDelay
         $current = \time();
 
         // check if delay necessary
-        $wait = $this->delaySeconds - ($current-$lastTimestamp);
+        $wait = $delaySeconds - ($current-$lastTimestamp);
         if ($wait > 0) {
             // wait now
             sleep($wait);
@@ -92,5 +88,23 @@ class CrawlDelay
         $current = \time();
         $this->lastCheckedDomainTimestamps[$domain] = $current;
         return true;
+    }
+
+    protected function getCrawlDelayByDomain(string $domain): int
+    {
+        if ($domain === '') {
+            return 0;
+        }
+
+        // check if domain should be skipped: do not use crawlDelay
+        if ($this->configuration->isCrawlDelayNoDelayRegex()) {
+            if (preg_match ($this->configuration->getCrawlDelayNoDelayRegex(), $domain)) {
+                return 0;
+            }
+        } else if (in_array($domain, $this->configuration->getCrawlDelayNodelayDomains())) {
+            // skip delay
+            return 0;
+        }
+        return $this->configuration->getCrawlDelaySeconds();
     }
 }

--- a/Classes/CheckLinks/CrawlDelay.php
+++ b/Classes/CheckLinks/CrawlDelay.php
@@ -98,10 +98,10 @@ class CrawlDelay
 
         // check if domain should be skipped: do not use crawlDelay
         if ($this->configuration->isCrawlDelayNoDelayRegex()) {
-            if (preg_match ($this->configuration->getCrawlDelayNoDelayRegex(), $domain)) {
+            if (preg_match($this->configuration->getCrawlDelayNoDelayRegex(), $domain)) {
                 return 0;
             }
-        } else if (in_array($domain, $this->configuration->getCrawlDelayNodelayDomains())) {
+        } elseif (in_array($domain, $this->configuration->getCrawlDelayNodelayDomains())) {
             // skip delay
             return 0;
         }

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -431,11 +431,46 @@ class Configuration
     }
 
     /**
+     * Return crawlDelay nodelay domains.
      * @return array<string>
+     * @deprecated Use getCrawlDelayNodelayDomains
      */
     public function getCrawlDelayNodelay(): array
     {
-        return explode(',', $this->tsConfig['crawlDelay.']['nodelay'] ?? '');
+        $noDelayString = $this->getCrawlDelayNodelayString();
+        if (str_starts_with($noDelayString, 'regex:')) {
+            return [];
+        } else {
+            return explode(',', $$noDelayString);
+        }
+    }
+
+    public function getCrawlDelayNodelayDomains(): array
+    {
+        $noDelayString = $this->getCrawlDelayNodelayString();
+        if (str_starts_with($noDelayString, 'regex:')) {
+            return [];
+        } else {
+            return explode(',', $noDelayString);
+        }
+    }
+
+    public function isCrawlDelayNoDelayRegex(): bool
+    {
+        return str_starts_with($this->getCrawlDelayNodelayString(), 'regex:');
+    }
+
+    public function getCrawlDelayNoDelayRegex(): string
+    {
+        if ($this->isCrawlDelayNoDelayRegex()) {
+            return trim(substr($this->getCrawlDelayNodelayString(), strlen('regex:')));
+        }
+        return '';
+    }
+
+    public function getCrawlDelayNodelayString(): string
+    {
+        return trim($this->tsConfig['crawlDelay.']['nodelay'] ?? '');
     }
 
     public function getDocsUrl(): string

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -440,9 +440,8 @@ class Configuration
         $noDelayString = $this->getCrawlDelayNodelayString();
         if (str_starts_with($noDelayString, 'regex:')) {
             return [];
-        } else {
-            return explode(',', $$noDelayString);
         }
+        return explode(',', $$noDelayString);
     }
 
     /**
@@ -454,9 +453,8 @@ class Configuration
         $noDelayString = $this->getCrawlDelayNodelayString();
         if (str_starts_with($noDelayString, 'regex:')) {
             return [];
-        } else {
-            return explode(',', $noDelayString);
         }
+        return explode(',', $noDelayString);
     }
 
     public function isCrawlDelayNoDelayRegex(): bool

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -445,6 +445,10 @@ class Configuration
         }
     }
 
+    /**
+     * Return crawlDelay.nodelay domains.
+     * @return array<string>awlDelayNodelayDomains
+     */
     public function getCrawlDelayNodelayDomains(): array
     {
         $noDelayString = $this->getCrawlDelayNodelayString();

--- a/Configuration/TsConfig/Page/pagetsconfig.tsconfig
+++ b/Configuration/TsConfig/Page/pagetsconfig.tsconfig
@@ -65,7 +65,7 @@ mod.brofix {
     # comma separated list of domains or regeix to not use crawlDelay (should be used for internal sites only!)
     # e.g. nodelay = example.org, example.com
     # e.g. nodelay = regex:/(.*\.)?example.(org|com)/
-    nodelay = 
+    nodelay =
   }
 
   report {

--- a/Configuration/TsConfig/Page/pagetsconfig.tsconfig
+++ b/Configuration/TsConfig/Page/pagetsconfig.tsconfig
@@ -62,8 +62,10 @@ mod.brofix {
     # minimum number of second delay between checking URLs of the same domain
     seconds = 5
 
-    # comma separated list of domains to not use crawlDelay (can be used for internal sites)
-    nodelay =
+    # comma separated list of domains or regeix to not use crawlDelay (should be used for internal sites only!)
+    # e.g. nodelay = example.org, example.com
+    # e.g. nodelay = regex:/(.*\.)?example.(org|com)/
+    nodelay = 
   }
 
   report {

--- a/Documentation/Setup/TsconfigReference.rst
+++ b/Documentation/Setup/TsconfigReference.rst
@@ -616,6 +616,10 @@ crawlDelay.nodelay
 
          crawlDelay.nodelay = example.org,example.com
 
+      .. code-block:: typoscript
+         :caption: regex example
+         crawlDelay.nodelay = regex:/(.*\.)?example.(org|com)/
+
    Default
       empty
 


### PR DESCRIPTION
E.g. by using this in TSconfig:

mod.brofix.crawlDelay.nodelay = regex:/(.*\.)?example.(org|com)/

Using nodelay, it is possible to exclude local domains from crawlDelay.