### PR TITLE
[BUGFIX] Use table variable in getSelectFields (#304)

### DIFF
--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -485,7 +485,7 @@ class LinkAnalyzer implements LoggerAwareInterface
             'uid',
             'pid'
         ];
-        if ($GLOBALS['TCA']['tt_content']['ctrl']['versioningWS'] ?? false) {
+        if ($GLOBALS['TCA'][$table]['ctrl']['versioningWS'] ?? false) {
             $defaultFields[] = 't3ver_wsid';
         }
         if (isset($GLOBALS['TCA'][$table]['ctrl']['label'])) {


### PR DESCRIPTION
The function getSelectFields used 'tt_content' instead of the $table variable in one place, which might result in exceptions if checking other tables.