### PR TITLE
[FEATURE] Make TCA processing configurable

### DIFF
--- a/Classes/FormEngine/FieldShouldBeCheckedWithFlexform.php
+++ b/Classes/FormEngine/FieldShouldBeCheckedWithFlexform.php
@@ -43,34 +43,36 @@ class FieldShouldBeCheckedWithFlexform implements FormDataGroupInterface
          */
         $orderedProviderList = GeneralUtility::makeInstance(OrderedProviderList::class);
         $orderedProviderList->setProviderList(
-            array_merge($GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['brofixFieldShouldBeChecked'],
-            [
-                \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessCommon::class => [
-                    'depends' => [
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaInlineExpandCollapseState::class,
+            array_merge(
+                $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['brofixFieldShouldBeChecked'],
+                [
+                    \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessCommon::class => [
+                        'depends' => [
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaInlineExpandCollapseState::class,
+                        ],
                     ],
-                ],
-                \TYPO3\CMS\Backend\Form\FormDataProvider\EvaluateDisplayConditions::class => [
-                    'depends' => [
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaRecordTitle::class,
+                    \TYPO3\CMS\Backend\Form\FormDataProvider\EvaluateDisplayConditions::class => [
+                        'depends' => [
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaRecordTitle::class,
+                        ],
                     ],
-                ],
-                \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class => [
-                    'depends' => [
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca::class,
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\UserTsConfig::class,
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\PageTsConfigMerged::class,
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsRemoveUnused::class,
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessFieldLabels::class,
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessFieldDescriptions::class,
+                    \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class => [
+                        'depends' => [
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\UserTsConfig::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\PageTsConfigMerged::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsRemoveUnused::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessFieldLabels::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessFieldDescriptions::class,
+                        ],
                     ],
-                ],
-                \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class => [
-                    'depends' => [
-                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class,
+                    \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class => [
+                        'depends' => [
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class,
+                        ],
                     ],
-                ],
-            ])
+                ]
+            )
         );
 
         return $orderedProviderList->compile($result);

--- a/Classes/FormEngine/FieldShouldBeCheckedWithFlexform.php
+++ b/Classes/FormEngine/FieldShouldBeCheckedWithFlexform.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Sypets\Brofix\FormEngine;
+
+use TYPO3\CMS\Backend\Form\FormDataGroup\OrderedProviderList;
+use TYPO3\CMS\Backend\Form\FormDataGroupInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Data provider group for checking if field should be checked for
+ * broken links.
+ *
+ * @internal
+ */
+class FieldShouldBeCheckedWithFlexform implements FormDataGroupInterface
+{
+    /**
+     * Compile form data
+     *
+     * @param mixed[] $result Initialized result array
+     * @return mixed[] Result filled with data
+     * @throws \UnexpectedValueException
+     */
+    public function compile(array $result): array
+    {
+        /**
+         * @var OrderedProviderList $orderedProviderList
+         */
+        $orderedProviderList = GeneralUtility::makeInstance(OrderedProviderList::class);
+        $orderedProviderList->setProviderList(
+            array_merge($GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['brofixFieldShouldBeChecked'],
+            [
+                \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessCommon::class => [
+                    'depends' => [
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaInlineExpandCollapseState::class,
+                    ],
+                ],
+                \TYPO3\CMS\Backend\Form\FormDataProvider\EvaluateDisplayConditions::class => [
+                    'depends' => [
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaRecordTitle::class,
+                    ],
+                ],
+                \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class => [
+                    'depends' => [
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca::class,
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\UserTsConfig::class,
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\PageTsConfigMerged::class,
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsRemoveUnused::class,
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessFieldLabels::class,
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessFieldDescriptions::class,
+                    ],
+                ],
+                \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class => [
+                    'depends' => [
+                        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class,
+                    ],
+                ],
+            ])
+        );
+
+        return $orderedProviderList->compile($result);
+    }
+}

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -139,12 +139,14 @@ class LinkAnalyzer implements LoggerAwareInterface
                 $uid = (int)$record['uid'];
                 $results = [];
 
-                // todo: for now we get entire record even though it is inefficient
-                // should optimize this in the  or make configurable
+                // todo: for tcaProcessing 'full', we get entire record even though it is inefficient, optimize this
                 // problem is we might need some fields for TCA parsing. In particular, when adding flexforms an exception might be thrown.
-                // $selectFields = $this->getSelectFields($table, [$record['field']]);
-                //$row = $this->contentRepository->getRowForUid($uid, $table, $selectFields);
-                $row = $this->contentRepository->getRowForUid($uid, $table, ['*']);
+                if ($this->configuration->getTcaProcessing() === Configuration::TCA_PROCESSING_FULL) {
+                    $row = $this->contentRepository->getRowForUid($uid, $table, ['*']);
+                } else {
+                    $selectFields = $this->getSelectFields($table, [$record['field']]);
+                    $row = $this->contentRepository->getRowForUid($uid, $table, $selectFields);
+                }
 
                 $this->linkParser->findLinksForRecord(
                     $results,
@@ -239,12 +241,14 @@ class LinkAnalyzer implements LoggerAwareInterface
         ServerRequestInterface $request,
         bool $checkHidden = false
     ): bool {
-        // todo: for now we get entire record even though it is inefficient
-        // should optimize this in the future or make configurable
+        // todo: for tcaProcessing 'full', we get entire record even though it is inefficient, optimize this
         // problem is we might need some fields for TCA parsing. In particular, when adding flexforms an exception might be thrown.
-        // $selectFields = $this->getSelectFields($table, [$field]);
-        //$row = $this->contentRepository->getRowForUid($recordUid, $table, $selectFields, $checkHidden);
-        $row = $this->contentRepository->getRowForUid($recordUid, $table, ['*'], $checkHidden);
+        if ($this->configuration->getTcaProcessing() === Configuration::TCA_PROCESSING_FULL) {
+            $row = $this->contentRepository->getRowForUid($recordUid, $table, ['*'], $checkHidden);
+        } else {
+            $selectFields = $this->getSelectFields($table, [$field]);
+            $row = $this->contentRepository->getRowForUid($recordUid, $table, $selectFields, $checkHidden);
+        }
 
         $startTime = \time();
 
@@ -457,9 +461,14 @@ class LinkAnalyzer implements LoggerAwareInterface
                     $selectFields = $tmpFields;
                 }
 
-                // todo: is inefficient, should optimize or make configurable
-                //$queryBuilder->select(...$selectFields)
-                $queryBuilder->select($table . '.*')
+                // todo: for tcaProcessing 'full', we get entire record even though it is inefficient, optimize this
+                // problem is we might need some fields for TCA parsing. In particular, when adding flexforms an exception might be thrown.
+                if ($this->configuration->getTcaProcessing() === Configuration::TCA_PROCESSING_FULL) {
+                    $queryBuilder->select($table . '.*');
+                } else {
+                    $queryBuilder->select(...$selectFields);
+                }
+                $queryBuilder
                     ->from($table)
                     ->where(
                         ...$constraints

--- a/Classes/Parser/LinkParser.php
+++ b/Classes/Parser/LinkParser.php
@@ -6,7 +6,6 @@ namespace Sypets\Brofix\Parser;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareTrait;
 use Sypets\Brofix\Configuration\Configuration;
-use Sypets\Brofix\FormEngine\FieldShouldBeChecked;
 use Sypets\Brofix\Linktype\AbstractLinktype;
 use Sypets\Brofix\Repository\ContentRepository;
 use Sypets\Brofix\Util\TcaUtil;
@@ -78,7 +77,6 @@ class LinkParser
             $contentRepository = GeneralUtility::makeInstance(ContentRepository::class);
         }
         $this->contentRepository = $contentRepository;
-
 
         self::$instance = $this;
     }

--- a/Classes/Parser/LinkParser.php
+++ b/Classes/Parser/LinkParser.php
@@ -102,6 +102,7 @@ class LinkParser
         $this->configuration = $configuration;
 
         $formDataGroup = GeneralUtility::makeInstance($this->configuration->getFormDataGroup());
+        /** @phpstan-ignore-next-line */
         if ($formDataGroup) {
             $this->formDataCompiler = GeneralUtility::makeInstance(FormDataCompiler::class, $formDataGroup);
         }

--- a/Classes/Parser/LinkParser.php
+++ b/Classes/Parser/LinkParser.php
@@ -50,7 +50,7 @@ class LinkParser
     public const MASK_CONTENT_CHECK_ALL = 0xff;
 
     protected ServerRequestInterface $request;
-    protected FormDataCompiler $formDataCompiler;
+    protected ?FormDataCompiler $formDataCompiler;
     protected Configuration $configuration;
     protected SoftReferenceParserFactory $softReferenceParserFactory;
     protected ContentRepository $contentRepository;
@@ -79,8 +79,6 @@ class LinkParser
         }
         $this->contentRepository = $contentRepository;
 
-        $formDataGroup = GeneralUtility::makeInstance(FieldShouldBeChecked::class);
-        $this->formDataCompiler = GeneralUtility::makeInstance(FormDataCompiler::class, $formDataGroup);
 
         self::$instance = $this;
     }
@@ -97,12 +95,18 @@ class LinkParser
             self::$instance = GeneralUtility::makeInstance(LinkParser::class);
         }
         self::$instance->setConfiguration($configuration);
+
         return self::$instance;
     }
 
     protected function setConfiguration(Configuration $configuration): void
     {
         $this->configuration = $configuration;
+
+        $formDataGroup = GeneralUtility::makeInstance($this->configuration->getFormDataGroup());
+        if ($formDataGroup) {
+            $this->formDataCompiler = GeneralUtility::makeInstance(FormDataCompiler::class, $formDataGroup);
+        }
     }
 
     /**
@@ -139,14 +143,19 @@ class LinkParser
 
             $processedFormData = $this->getProcessedFormData($idRecord, $table, $request);
 
-            if ($checks & self::MASK_CONTENT_CHECK_IF_EDITABLE_FIELD) {
+            if ($checks & self::MASK_CONTENT_CHECK_IF_EDITABLE_FIELD && $processedFormData) {
                 $fields = $this->getEditableFields($idRecord, $table, $fields, $processedFormData);
             }
+            if (!$fields) {
+                return [];
+            }
+
+            $tableTca = $this->processedFormData ? $this->processedFormData['processedTca'] : $GLOBALS['TCA'][$table];
 
             // Get all links/references
             foreach ($fields as $field) {
                 // use the processedTca to also  get overridden configuration (e.g. columnsOverrides)
-                $fieldConfig = $this->processedFormData['processedTca']['columns'][$field]['config'];
+                $fieldConfig = $tableTca['columns'][$field]['config'];
                 $valueField = htmlspecialchars_decode((string)($record[$field]));
                 if ($valueField === '') {
                     continue;
@@ -459,6 +468,10 @@ class LinkParser
      */
     public function getProcessedFormData(int $uid, string $tablename, ServerRequestInterface $request): array
     {
+        if (!$this->formDataCompiler) {
+            return [];
+        }
+
         // is hack
         $isAdmin = true;
         // form data processing should be performed as admin, because we do not want to apply permission checks here

--- a/Documentation/Changelog/Entries/6.x/Feature-Support-checking-in-flexforms.rst
+++ b/Documentation/Changelog/Entries/6.x/Feature-Support-checking-in-flexforms.rst
@@ -7,6 +7,10 @@ Feature - Support checking in Flexforms
 **This feature can be used and has been tested, but should be considered
 experimental until further notice!**
 
+**For Flexform checking to fully work, you must set
+:ref:`tcaProcessing <extensionConfiguation_tcaProcessing>` to "full"
+in the extension configuration for brofix.**
+
 Since Flexforms consist of nested fields, checking these kind of fields needed
 modified functionality. It is now possible to also check Flexforms for
 broken links.
@@ -43,6 +47,9 @@ Using this new feature
 
       mod.brofix.searchFields.tt_content = bodytext,header_link,records,pi_flexform
 
+#. In the extension configuration for brofix, set tcaProcessing to "full"
+
+
 #. Check your fields in your Flexform configuration, to make sure, you are
    using field configuration which will be checked by brofix (see the
    "Implementation" section), such as type ":ref:`link <t3tca:columns-link>"
@@ -57,7 +64,7 @@ This new feature comes with some caveats:
 
 #. It is not possible to edit the field with the broken link directly: When
    clicking the edit button in the broken link list, an edit dialog is opened
-   for all fields in the flexform. For non-Flexform fields, the edit dialog
+   for all fields in the flexform while for non-Flexform fields, the edit dialog
    will show only the affected field. The advantage of showing only the affected
    field is that it is easier to find the broken link, especially in non-RTE
    fields where the broken link is not highlighted. (The reason for this caveat
@@ -67,6 +74,10 @@ This new feature comes with some caveats:
 #. It is not possible to specify directly which fields in the Flexform will
    be checked. The fields which are checked is derived directly form the field
    configuration (type, renderType, enableRichtext and softref).
+
+#. In order for the Flexform processing to work the full record is fetched from
+   the database. This makes the process possibly slightly slower and less
+   efficient, but should not have a big impact.
 
 Some of these caveats may be addressed in future releases.
 

--- a/Documentation/Setup/Reference.rst
+++ b/Documentation/Setup/Reference.rst
@@ -73,7 +73,10 @@ link checking is performed, using the default template in this extension.
 Extension configuration
 =======================
 
-**EXT:backend | loginLogo:**  *Logo ...*
+EXT:backend | loginLogo
+-----------------------
+
+*Logo ...*
 
 Set the logo used in the Fluid email in the EXT:backend extension configuration:
 
@@ -81,9 +84,10 @@ Set the logo used in the Fluid email in the EXT:backend extension configuration:
 
    $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['backend']['login.loginLogo'] = 'EXT:my_theme/Resources/Public/Images/login-logo.png or //domain.tld/login-logo.png';
 
------
+EXT:brofix | traverseMaxNumberOfPagesInBackend
+----------------------------------------------
 
-**EXT:brofix | traverseMaxNumberOfPagesInBackend:** *Maximum number of pages to traverse in Backend ...*
+*Maximum number of pages to traverse in Backend ...*
 
 Set the maximum number of pages traversed in the backend module.
 This should be limited so that loading the broken link list in the backend
@@ -101,6 +105,19 @@ on the performance of your site, you should use a limit such as 1000 (thousand).
    always traverse through all subpages of the current page (unless the level
    is restricted in the form). The traversing of the pages is not cached and
    may cause considerable delays.
+
+.. _extensionConfiguation_tcaProcessing:
+
+EXT:brofix | tcaProcessing
+--------------------------
+
+
+*Perform TCA processing*
+
+Changes how the TCA processing is done. The default setting may not work
+for some configurations and especially for Flexforms. In that case, it should
+be set to "full". This setting is still experimental, so it is not on by
+default.
 
 
 Tsconfig

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -7,10 +7,7 @@ excludeSoftrefsInFields = tt_content.bodytext
 # cat=basic; type=int; label= Maximum number of pages to traverse in Backend. Limit is disabled if =0. This should be set to a hard limit for performance reasons.
 traverseMaxNumberOfPagesInBackend = 1000
 
-# cat=basic; type=string; label= FormDataGroup for processing TCA
-traverseMaxNumberOfPagesInBackend = 1000
-
-# cat=basic; type=options[None=none,default=default,full=full]; label= Perform TCA processing (see documentation for details)
+# cat=basic; type=options[default=default,full=full]; label= Perform TCA processing (see documentation for details)
 tcaProcessing = default
 
 # cat=basic; type=string; label= Override FormDataGroup for processing TCA (see documentation for details)

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -56,8 +56,6 @@ defined('TYPO3') or die();
 
     // for link checking, do not perform user permission checks, only check if field is editable
     // permission checks are done when reading records from tx_brofix_broken_links for report
-
-    // legacy: worked but did not include flexform and some other providers
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['brofixFieldShouldBeChecked'] = [
         \TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca::class => [],
         \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseEditRow::class => [


### PR DESCRIPTION
Make some changes to previous feature of modifying TCA processing to check for Flexform: The TCA processing is made configurable. This can be configured in the Extension Configuration, since this is considered a system-wide configuration and should no be overridden by TSconfig.

For processing Flexforms it is currently necessary to choose tcaProcessing="full" in the Extension Configuration.

The previous Changelog is updated accordingly.