### PR TITLE
[FEATURE] Make TCA processing configurable (#311)

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -18,6 +18,9 @@ declare(strict_types=1);
 namespace Sypets\Brofix\Configuration;
 
 use Symfony\Component\Mime\Address;
+use Sypets\Brofix\FormEngine\FieldShouldBeChecked;
+use Sypets\Brofix\FormEngine\FieldShouldBeCheckedFull;
+use Sypets\Brofix\FormEngine\FieldShouldBeCheckedWithFlexform;
 use Sypets\Brofix\Linktype\AbstractLinktype;
 use Sypets\Brofix\Linktype\LinktypeInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -93,6 +96,12 @@ class Configuration
         'custom.' => []
     ];
 
+    protected const TCA_PROCESSING_DEFAULT_VALUE = self::TCA_PROCESSING_DEFAULT;
+
+    public const TCA_PROCESSING_NONE = 'none';
+    public const TCA_PROCESSING_DEFAULT = 'default';
+    public const TCA_PROCESSING_FULL = 'full';
+
     /**
      * @var mixed[]
      * @todo replace this array and use member variables for all values
@@ -131,6 +140,10 @@ class Configuration
      */
     protected array $hookObjectsArr = [];
 
+    protected string $tcaProcessing = self::TCA_PROCESSING_DEFAULT_VALUE;
+
+    protected string $overrideFormDataGroup = '';
+
     /**
      * Configuration constructor.
      * @param array<mixed> $extConfArray ExtensionConfiguration array
@@ -146,6 +159,8 @@ class Configuration
             (int)($extConfArray['traverseMaxNumberOfPagesInBackend']
                 ?? self::TRAVERSE_MAX_NUMBER_OF_PAGES_IN_BACKEND_DEFAULT)
         );
+        $this->tcaProcessing = $extConfArray['tcaProcessing'] ?? self::TCA_PROCESSING_DEFAULT_VALUE;
+        $this->overrideFormDataGroup = $extConfArray['overrideFormDataGroup'] ?? '';
 
         // initialize from global configuration
         // Hook to handle own checks
@@ -664,6 +679,33 @@ class Configuration
     public function getCombinedErrorNonCheckableMatch(): string
     {
         return $this->combinedErrorNonCheckableMatch;
+    }
+
+    public function getTcaProcessing(): string
+    {
+        return $this->tcaProcessing;
+    }
+
+    public function getOverrideFormDataGroup(): string
+    {
+        return $this->overrideFormDataGroup;
+    }
+
+    public function getFormDataGroup(): string
+    {
+        if ($this->overrideFormDataGroup) {
+            return $this->overrideFormDataGroup;
+        }
+        switch ($this->getTcaProcessing()) {
+            case self::TCA_PROCESSING_NONE:
+                return '';
+            case self::TCA_PROCESSING_DEFAULT:
+                return FieldShouldBeChecked::class;
+            case self::TCA_PROCESSING_FULL:
+                //return FieldShouldBeCheckedFull::class;
+                return FieldShouldBeCheckedWithFlexform::class;
+        }
+        return '';
     }
 
     public function getLinktypeObject(string $linktype): ?LinktypeInterface

--- a/Classes/FormEngine/FieldShouldBeCheckedWithFlexform.php
+++ b/Classes/FormEngine/FieldShouldBeCheckedWithFlexform.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Sypets\Brofix\FormEngine;
+
+use TYPO3\CMS\Backend\Form\FormDataGroup\OrderedProviderList;
+use TYPO3\CMS\Backend\Form\FormDataGroupInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Data provider group for checking if field should be checked for
+ * broken links.
+ *
+ * @internal
+ */
+class FieldShouldBeCheckedWithFlexform implements FormDataGroupInterface
+{
+    /**
+     * Compile form data
+     *
+     * @param mixed[] $result Initialized result array
+     * @return mixed[] Result filled with data
+     * @throws \UnexpectedValueException
+     */
+    public function compile(array $result): array
+    {
+        /**
+         * @var OrderedProviderList $orderedProviderList
+         */
+        $orderedProviderList = GeneralUtility::makeInstance(OrderedProviderList::class);
+        $orderedProviderList->setProviderList(
+            array_merge(
+                $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['brofixFieldShouldBeChecked'],
+                [
+                    \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessCommon::class => [
+                        'depends' => [
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaInlineExpandCollapseState::class,
+                        ],
+                    ],
+                    \TYPO3\CMS\Backend\Form\FormDataProvider\EvaluateDisplayConditions::class => [
+                        'depends' => [
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaRecordTitle::class,
+                        ],
+                    ],
+                    \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class => [
+                        'depends' => [
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\UserTsConfig::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\PageTsConfigMerged::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsRemoveUnused::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessFieldLabels::class,
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessFieldDescriptions::class,
+                        ],
+                    ],
+                    \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class => [
+                        'depends' => [
+                            \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class,
+                        ],
+                    ],
+                ]
+            )
+        );
+
+        return $orderedProviderList->compile($result);
+    }
+}

--- a/Classes/Parser/LinkParser.php
+++ b/Classes/Parser/LinkParser.php
@@ -102,6 +102,7 @@ class LinkParser
     {
         $this->configuration = $configuration;
 
+        /** @phpstan-ignore-next-line */
         $formDataGroup = GeneralUtility::makeInstance($this->configuration->getFormDataGroup());
         /** @phpstan-ignore-next-line */
         if ($formDataGroup) {

--- a/Classes/Parser/LinkParser.php
+++ b/Classes/Parser/LinkParser.php
@@ -79,10 +79,6 @@ class LinkParser
         }
         $this->contentRepository = $contentRepository;
 
-        $formDataGroup = GeneralUtility::makeInstance(FieldShouldBeChecked::class);
-        //$formDataGroup = GeneralUtility::makeInstance(TcaDatabaseRecord::class);
-        $this->formDataCompiler = GeneralUtility::makeInstance(FormDataCompiler::class, $formDataGroup);
-
         self::$instance = $this;
     }
 

--- a/Classes/Parser/LinkParser.php
+++ b/Classes/Parser/LinkParser.php
@@ -6,7 +6,6 @@ namespace Sypets\Brofix\Parser;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareTrait;
 use Sypets\Brofix\Configuration\Configuration;
-use Sypets\Brofix\FormEngine\FieldShouldBeChecked;
 use Sypets\Brofix\Linktype\AbstractLinktype;
 use Sypets\Brofix\Repository\ContentRepository;
 use Sypets\Brofix\Util\TcaUtil;
@@ -51,7 +50,7 @@ class LinkParser
     public const MASK_CONTENT_CHECK_ALL = 0xff;
 
     protected ?ServerRequestInterface $request;
-    protected FormDataCompiler $formDataCompiler;
+    protected ?FormDataCompiler $formDataCompiler;
     protected Configuration $configuration;
     protected SoftReferenceParserFactory $softReferenceParserFactory;
     protected ContentRepository $contentRepository;
@@ -99,12 +98,19 @@ class LinkParser
             self::$instance = GeneralUtility::makeInstance(LinkParser::class);
         }
         self::$instance->setConfiguration($configuration);
+
         return self::$instance;
     }
 
     protected function setConfiguration(Configuration $configuration): void
     {
         $this->configuration = $configuration;
+
+        $formDataGroup = GeneralUtility::makeInstance($this->configuration->getFormDataGroup());
+        /** @phpstan-ignore-next-line */
+        if ($formDataGroup) {
+            $this->formDataCompiler = GeneralUtility::makeInstance(FormDataCompiler::class, $formDataGroup);
+        }
     }
 
     /**
@@ -142,14 +148,19 @@ class LinkParser
 
             $processedFormData = $this->getProcessedFormData($idRecord, $table, $request);
 
-            if ($checks & self::MASK_CONTENT_CHECK_IF_EDITABLE_FIELD) {
+            if ($checks & self::MASK_CONTENT_CHECK_IF_EDITABLE_FIELD && $processedFormData) {
                 $fields = $this->getEditableFields($idRecord, $table, $fields, $processedFormData);
             }
+            if (!$fields) {
+                return [];
+            }
+
+            $tableTca = $this->processedFormData ? $this->processedFormData['processedTca'] : $GLOBALS['TCA'][$table];
 
             // Get all links/references
             foreach ($fields as $field) {
                 // use the processedTca to also  get overridden configuration (e.g. columnsOverrides)
-                $fieldConfig = $this->processedFormData['processedTca']['columns'][$field]['config'];
+                $fieldConfig = $tableTca['columns'][$field]['config'];
                 $valueField = htmlspecialchars_decode((string)($record[$field]));
                 if ($valueField === '') {
                     continue;
@@ -456,6 +467,10 @@ class LinkParser
      */
     public function getProcessedFormData(int $uid, string $tablename, ServerRequestInterface $request): array
     {
+        if (!$this->formDataCompiler) {
+            return [];
+        }
+
         // is hack
         $isAdmin = true;
         // form data processing should be performed as admin, because we do not want to apply permission checks here

--- a/Classes/Parser/LinkParser.php
+++ b/Classes/Parser/LinkParser.php
@@ -11,7 +11,6 @@ use Sypets\Brofix\Repository\ContentRepository;
 use Sypets\Brofix\Util\TcaUtil;
 use TYPO3\CMS\Backend\Form\Exception\DatabaseDefaultLanguageException;
 use TYPO3\CMS\Backend\Form\FormDataCompiler;
-use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 use TYPO3\CMS\Core\DataHandling\SoftReference\SoftReferenceParserFactory;
 use TYPO3\CMS\Core\DataHandling\SoftReference\SoftReferenceParserInterface;
 use TYPO3\CMS\Core\DataHandling\SoftReference\SoftReferenceParserResult;

--- a/Documentation/Changelog/Entries/6.x/Feature-Support-checking-in-flexforms.rst
+++ b/Documentation/Changelog/Entries/6.x/Feature-Support-checking-in-flexforms.rst
@@ -7,6 +7,10 @@ Feature - Support checking in Flexforms
 **This feature can be used and has been tested, but should be considered
 experimental until further notice!**
 
+**For Flexform checking to fully work, you must set
+:ref:`tcaProcessing <extensionConfiguation_tcaProcessing>` to "full"
+in the extension configuration for brofix.**
+
 Since Flexforms consist of nested fields, checking these kind of fields needed
 modified functionality. It is now possible to also check Flexforms for
 broken links.
@@ -43,6 +47,9 @@ Using this new feature
 
       mod.brofix.searchFields.tt_content = bodytext,header_link,records,pi_flexform
 
+#. In the extension configuration for brofix, set tcaProcessing to "full"
+
+
 #. Check your fields in your Flexform configuration, to make sure, you are
    using field configuration which will be checked by brofix (see the
    "Implementation" section), such as type ":ref:`link <t3tca:columns-link>"
@@ -57,7 +64,7 @@ This new feature comes with some caveats:
 
 #. It is not possible to edit the field with the broken link directly: When
    clicking the edit button in the broken link list, an edit dialog is opened
-   for all fields in the flexform. For non-Flexform fields, the edit dialog
+   for all fields in the flexform while for non-Flexform fields, the edit dialog
    will show only the affected field. The advantage of showing only the affected
    field is that it is easier to find the broken link, especially in non-RTE
    fields where the broken link is not highlighted. (The reason for this caveat
@@ -67,6 +74,10 @@ This new feature comes with some caveats:
 #. It is not possible to specify directly which fields in the Flexform will
    be checked. The fields which are checked is derived directly form the field
    configuration (type, renderType, enableRichtext and softref).
+
+#. In order for the Flexform processing to work the full record is fetched from
+   the database. This makes the process possibly slightly slower and less
+   efficient, but should not have a big impact.
 
 Some of these caveats may be addressed in future releases.
 

--- a/Documentation/Setup/ExtensionConfigurationReference.rst
+++ b/Documentation/Setup/ExtensionConfigurationReference.rst
@@ -108,3 +108,15 @@ This is the default value:
 .. code-block:: text
 
    regex:/^(httpStatusCode:(401|403):|libcurlErrno:60:SSL certificate problem: unable to get local issuer certificate)/
+
+.. _extensionConfiguation_tcaProcessing:
+
+EXT:brofix | tcaProcessing
+--------------------------
+
+*Perform TCA processing*
+
+Changes how the TCA processing is done. The default setting may not work
+for some configurations and especially for Flexforms. In that case, it should
+be set to "full". This setting is still experimental, so it is not on by
+default.

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -12,3 +12,9 @@ showalllinks = 1
 
 # cat=basic; type=bool; label=Non-checkable match: If check result matches this, link target is considered non-checkable, can be a regex if start with regex: or match start of, is errortype:errorcode:exception message
 combinedErrorNonCheckableMatch = regex:/^(httpStatusCode:(401|403):|libcurlErrno:60:SSL certificate problem: unable to get local issuer certificate)/
+
+# cat=basic; type=options[default=default,full=full]; label= Perform TCA processing (see documentation for details)
+tcaProcessing = default
+
+# cat=basic; type=string; label= Override FormDataGroup for processing TCA (see documentation for details)
+overrideFormDataGroup =

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -89,6 +89,7 @@ defined('TYPO3') or die();
                 \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRecordTypeValue::class,
             ],
         ],
+    ];
 
     if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'])) {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['brofixFieldShouldBeChecked'] =

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -57,8 +57,38 @@ defined('TYPO3') or die();
 
     // for link checking, do not perform user permission checks, only check if field is editable
     // permission checks are done when reading records from tx_brofix_broken_links for report
-
-    // use core formDataGroup, slightly modified
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['brofixFieldShouldBeChecked'] = [
+        \TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca::class => [],
+        \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseEditRow::class => [
+            'depends' => [
+                \TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca::class,
+            ]
+        ],
+        \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew::class => [
+            'depends' => [
+                \TYPO3\CMS\Backend\Form\FormDataProvider\PageTsConfig::class,
+                \TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca::class,
+            ],
+        ],
+        \TYPO3\CMS\Backend\Form\FormDataProvider\DatabasePageLanguageOverlayRows::class => [
+            'depends' => [
+            ],
+        ],
+        \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseLanguageRows::class => [
+            'depends' => [
+                \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowInitializeNew::class,
+            ],
+        ],
+        \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRecordTypeValue::class => [
+            'depends' => [
+                \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseLanguageRows::class,
+            ],
+        ],
+        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsOverrides::class => [
+            'depends' => [
+                \TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRecordTypeValue::class,
+            ],
+        ],
 
     if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'])) {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['brofixFieldShouldBeChecked'] =


### PR DESCRIPTION
* [FEATURE] Make TCA processing configurable

Make some changes to previous feature of modifying TCA processing to check for Flexform: The TCA processing is made configurable. This can be configured in the Extension Configuration, since this is considered a system-wide configuration and should no be overridden by TSconfig.

For processing Flexforms it is currently necessary to choose tcaProcessing="full" in the Extension Configuration.

The previous Changelog is updated accordingly.