### PR TITLE
[FEATURE] Add configuration options for sending email

### DIFF
--- a/Classes/CheckLinks/CheckLinksStatistics.php
+++ b/Classes/CheckLinks/CheckLinksStatistics.php
@@ -48,7 +48,7 @@ class CheckLinksStatistics
      */
     protected $countLinksTotal = 0;
 
-    protected $countNewBrokenLinks = 0;
+    protected int $countNewBrokenLinks = 0;
 
     public function __construct()
     {

--- a/Classes/CheckLinks/CheckLinksStatistics.php
+++ b/Classes/CheckLinks/CheckLinksStatistics.php
@@ -46,7 +46,9 @@ class CheckLinksStatistics
     /**
      * @var int
      */
-    protected $countLinksTotal;
+    protected $countLinksTotal = 0;
+
+    protected $countNewBrokenLinks = 0;
 
     public function __construct()
     {
@@ -58,6 +60,7 @@ class CheckLinksStatistics
         $this->checkStartTime = \time();
         $this->countPages = 0;
         $this->countLinksTotal = 0;
+        $this->countNewBrokenLinks = 0;
         $this->countLinksByStatus = [];
         $this->pageTitle = '';
     }
@@ -74,6 +77,16 @@ class CheckLinksStatistics
         }
         $this->countLinksByStatus[$status]++;
         $this->countLinksTotal++;
+    }
+
+    public function incrementNewBrokenLink(): void
+    {
+        $this->countNewBrokenLinks++;
+    }
+
+    public function getCountNewBrokenLinks(): int
+    {
+        return $this->countNewBrokenLinks;
     }
 
     public function incrementCountExcludedLinks(): void

--- a/Classes/Command/CheckLinksCommand.php
+++ b/Classes/Command/CheckLinksCommand.php
@@ -160,7 +160,7 @@ class CheckLinksCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Send email. Possible values: ' . implode(' | ', Configuration::SEND_EMAIL_AVAILABLE_VALUES)
                     . ' (default:' . Configuration::SEND_EMAIL_DEFAULT_VALUE . ')',
-                Configuration::SEND_EMAIL_DEFAULT_VALUE,
+                Configuration::SEND_EMAIL_AUTO,
                 Configuration::SEND_EMAIL_AVAILABLE_VALUES
             )
             ->addOption(
@@ -197,7 +197,7 @@ class CheckLinksCommand extends Command
             $this->io->writeln('Dry run is activated, do not check and do not send email');
         }
 
-        $this->sendEmail = ($input->getOption('send-email') ?? Configuration::SEND_EMAIL_DEFAULT_VALUE);
+        $this->sendEmail = ($input->getOption('send-email') ?? Configuration::SEND_EMAIL_AUTO);
         // map old values
         switch ($this->sendEmail) {
             case '0':
@@ -212,15 +212,15 @@ class CheckLinksCommand extends Command
         }
 
         if ($this->sendEmail === Configuration::SEND_EMAIL_NEVER) {
-            $this->io->writeln('Do not send email.');
+            $this->io->writeln('Do not send email (never).');
         } else if ($this->sendEmail === Configuration::SEND_EMAIL_ALWAYS) {
-            $this->io->writeln('Always send email.');
+            $this->io->writeln('Always send email (always).');
         } if ($this->sendEmail === Configuration::SEND_EMAIL_ANY) {
-            $this->io->writeln('Send email only if broken links found.');
+            $this->io->writeln('Send email only if broken links found (any).');
         } if ($this->sendEmail === Configuration::SEND_EMAIL_NEW) {
-            $this->io->writeln('Send email only if new broken links found.');
+            $this->io->writeln('Send email only if new broken links found (new).');
         } if ($this->sendEmail === Configuration::SEND_EMAIL_AUTO) {
-            $this->io->writeln('Send email based on TSconfig configuration.');
+            $this->io->writeln('Send email based on TSconfig configuration (auto).');
         }
 
         // exluded pages uid

--- a/Classes/Command/CheckLinksCommand.php
+++ b/Classes/Command/CheckLinksCommand.php
@@ -16,6 +16,7 @@ namespace Sypets\Brofix\Command;
  * The TYPO3 project - inspiring people to share!
  */
 
+use RdKafka\Conf;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -61,8 +62,12 @@ class CheckLinksCommand extends Command
     protected $sendTo;
 
     /**
-     * @var int -1: means use default (from configuration),
-     *   1 means send email, 0 means do not send
+     * @var string "never" | "always" | "any" | "new" | "auto"
+     *
+     * older values, deprecated:
+     *   -1 => "auto" : use default (from configuration),
+     *   1 => "always": always send email
+     *   0 => "never" : do not send
      */
     protected $sendEmail;
 
@@ -152,8 +157,11 @@ class CheckLinksCommand extends Command
             ->addOption(
                 'send-email',
                 'e',
-                InputOption::VALUE_OPTIONAL,
-                'Send email (override configuration). 1: send, 0: do not send'
+                InputOption::VALUE_REQUIRED,
+                'Send email. Possible values: ' . implode(' | ', Configuration::SEND_EMAIL_AVAILABLE_VALUES)
+                    . ' (default:' . Configuration::SEND_EMAIL_DEFAULT_VALUE . ')',
+                Configuration::SEND_EMAIL_DEFAULT_VALUE,
+                Configuration::SEND_EMAIL_AVAILABLE_VALUES
             )
             ->addOption(
                 'exclude-uid',
@@ -189,9 +197,30 @@ class CheckLinksCommand extends Command
             $this->io->writeln('Dry run is activated, do not check and do not send email');
         }
 
-        $this->sendEmail = (int)($input->getOption('send-email') ?? -1);
-        if ($this->sendEmail === 0) {
+        $this->sendEmail = ($input->getOption('send-email') ?? Configuration::SEND_EMAIL_DEFAULT_VALUE);
+        // map old values
+        switch ($this->sendEmail) {
+            case '0':
+                $this->sendEmail = Configuration::SEND_EMAIL_NEVER;
+                break;
+            case '1':
+                $this->sendEmail = Configuration::SEND_EMAIL_ALWAYS;
+                break;
+            case '-1':
+                $this->sendEmail = Configuration::SEND_EMAIL_AUTO;
+                break;
+        }
+
+        if ($this->sendEmail === Configuration::SEND_EMAIL_NEVER) {
             $this->io->writeln('Do not send email.');
+        } else if ($this->sendEmail === Configuration::SEND_EMAIL_ALWAYS) {
+            $this->io->writeln('Always send email.');
+        } if ($this->sendEmail === Configuration::SEND_EMAIL_ANY) {
+            $this->io->writeln('Send email only if broken links found.');
+        } if ($this->sendEmail === Configuration::SEND_EMAIL_NEW) {
+            $this->io->writeln('Send email only if new broken links found.');
+        } if ($this->sendEmail === Configuration::SEND_EMAIL_AUTO) {
+            $this->io->writeln('Send email based on TSconfig configuration.');
         }
 
         // exluded pages uid
@@ -255,13 +284,13 @@ class CheckLinksCommand extends Command
             if ($this->sendTo !== '') {
                 $this->configuration->setMailRecipientsAsString($this->sendTo);
             }
-            if ($this->sendEmail === 0) {
-                $this->configuration->setMailSendOnCheckLinks(0);
+            if ($this->sendEmail !== Configuration::SEND_EMAIL_AUTO) {
+                $this->configuration->setMailSendOnCheckLinks($this->sendEmail);
             }
 
             // show configuration
-            if ($this->configuration->getMailSendOnCheckLinks()) {
-                $this->io->writeln('Configuration: Send mail: true');
+            if ($this->configuration->getMailSendOnCheckLinks() !== Configuration::SEND_EMAIL_NEVER) {
+                $this->io->writeln('Configuration: Send mail: ' . $this->configuration->getMailSendOnCheckLinks());
                 $recipients = $this->configuration->getMailRecipients();
                 $to = '';
                 foreach ($recipients as $recipient) {
@@ -311,10 +340,34 @@ class CheckLinksCommand extends Command
                 (string)($depth === 999 ? 'infinite' : $depth),
                 $stats->getCountBrokenLinks()
             ));
-            if ($this->configuration->getMailSendOnCheckLinks()) {
-                $this->generateCheckResultMail->generateMail($this->configuration, $this->statistics[$pageId], $pageId);
-            } else {
-                $this->io->writeln('Do not send mail, because sending was deactivated.');
+            switch ($this->configuration->getMailSendOnCheckLinks()) {
+                case Configuration::SEND_EMAIL_NEVER:
+                    $this->io->writeln('Do not send mail, because sending was deactivated.');
+                    break;
+                case Configuration::SEND_EMAIL_ALWAYS:
+                    $this->io->writeln('Send email');
+                    $this->generateCheckResultMail->generateMail($this->configuration, $this->statistics[$pageId], $pageId);
+                    break;
+                case Configuration::SEND_EMAIL_ANY:
+                    if ($stats->getCountBrokenLinks()) {
+                        $this->io->writeln('Broken links found, send email');
+                        $this->generateCheckResultMail->generateMail($this->configuration, $this->statistics[$pageId],
+                            $pageId);
+                    } else {
+                        $this->io->writeln('No broken links found, do not send email');
+                    }
+                    break;
+                case Configuration::SEND_EMAIL_NEW:
+                    // send email only if new broken links
+                    $newBrokenLinks = $stats->getCountNewBrokenLinks();
+                    if ($newBrokenLinks) {
+                        $this->io->writeln($newBrokenLinks . ' new broken links found, send email');
+                        $this->generateCheckResultMail->generateMail($this->configuration, $this->statistics[$pageId],
+                            $pageId);
+                    } else {
+                        $this->io->writeln('No new broken links found, do not send email');
+                    }
+
             }
         }
 

--- a/Classes/Command/CheckLinksCommand.php
+++ b/Classes/Command/CheckLinksCommand.php
@@ -16,7 +16,6 @@ namespace Sypets\Brofix\Command;
  * The TYPO3 project - inspiring people to share!
  */
 
-use RdKafka\Conf;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -213,7 +212,7 @@ class CheckLinksCommand extends Command
 
         if ($this->sendEmail === Configuration::SEND_EMAIL_NEVER) {
             $this->io->writeln('Do not send email (never).');
-        } else if ($this->sendEmail === Configuration::SEND_EMAIL_ALWAYS) {
+        } elseif ($this->sendEmail === Configuration::SEND_EMAIL_ALWAYS) {
             $this->io->writeln('Always send email (always).');
         } if ($this->sendEmail === Configuration::SEND_EMAIL_ANY) {
             $this->io->writeln('Send email only if broken links found (any).');
@@ -351,8 +350,11 @@ class CheckLinksCommand extends Command
                 case Configuration::SEND_EMAIL_ANY:
                     if ($stats->getCountBrokenLinks()) {
                         $this->io->writeln('Broken links found, send email');
-                        $this->generateCheckResultMail->generateMail($this->configuration, $this->statistics[$pageId],
-                            $pageId);
+                        $this->generateCheckResultMail->generateMail(
+                            $this->configuration,
+                            $this->statistics[$pageId],
+                            $pageId
+                        );
                     } else {
                         $this->io->writeln('No broken links found, do not send email');
                     }
@@ -362,12 +364,14 @@ class CheckLinksCommand extends Command
                     $newBrokenLinks = $stats->getCountNewBrokenLinks();
                     if ($newBrokenLinks) {
                         $this->io->writeln($newBrokenLinks . ' new broken links found, send email');
-                        $this->generateCheckResultMail->generateMail($this->configuration, $this->statistics[$pageId],
-                            $pageId);
+                        $this->generateCheckResultMail->generateMail(
+                            $this->configuration,
+                            $this->statistics[$pageId],
+                            $pageId
+                        );
                     } else {
                         $this->io->writeln('No new broken links found, do not send email');
                     }
-
             }
         }
 

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -39,6 +39,25 @@ use TYPO3\CMS\Core\Utility\MailUtility;
  */
 class Configuration
 {
+    public const SEND_EMAIL_NEVER = 'never';
+
+    /** @var string Always send email */
+    public const SEND_EMAIL_ALWAYS = 'always';
+
+    /** @var string Send email if any broken links found */
+    public const SEND_EMAIL_ANY = 'any';
+
+    /** @var string Send email if any NEW broken links found */
+    public const SEND_EMAIL_NEW = 'new';
+
+    /** @var string Do not override configuration for email sending */
+    public const SEND_EMAIL_AUTO = 'auto';
+
+    public const SEND_EMAIL_DEFAULT_VALUE = self::SEND_EMAIL_AUTO;
+
+    public const SEND_EMAIL_AVAILABLE_VALUES = [self::SEND_EMAIL_NEVER, self::SEND_EMAIL_ALWAYS, self::SEND_EMAIL_ANY,
+        self::SEND_EMAIL_NEW, self::SEND_EMAIL_AUTO];
+
     public const TRAVERSE_MAX_NUMBER_OF_PAGES_IN_BACKEND_DEFAULT = 1000;
     public const DEFAULT_TSCONFIG = [
         'searchFields.' => [
@@ -507,14 +526,28 @@ class Configuration
         return (int)($this->tsConfig['report.']['recheckButton'] ?? -1);
     }
 
-    public function getMailSendOnCheckLinks(): bool
+    public function getMailSendOnCheckLinks(): string
     {
-        return (bool)($this->tsConfig['mail.']['sendOnCheckLinks'] ?? true);
+        $value = ($this->tsConfig['mail.']['sendOnCheckLinks'] ?? self::SEND_EMAIL_DEFAULT_VALUE);
+        switch ($value) {
+            case self::SEND_EMAIL_AUTO:
+                return self::SEND_EMAIL_DEFAULT_VALUE;
+            // map old values
+            case '0':
+                return self::SEND_EMAIL_NEVER;
+            case '1':
+                return self::SEND_EMAIL_ALWAYS;
+            case '-1':
+                return self::SEND_EMAIL_DEFAULT_VALUE;
+        }
+        return $value;
     }
 
-    public function setMailSendOnCheckLinks(int $value): void
+    public function setMailSendOnCheckLinks(string $value): void
     {
-        $this->tsConfig['mail.']['sendOnCheckLinks'] = $value;
+        if ($value !== self::SEND_EMAIL_AUTO) {
+            $this->tsConfig['mail.']['sendOnCheckLinks'] = $value;
+        }
     }
 
     /**

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -532,7 +532,7 @@ class Configuration
         switch ($value) {
             case self::SEND_EMAIL_AUTO:
                 return self::SEND_EMAIL_DEFAULT_VALUE;
-            // map old values
+                // map old values
             case '0':
                 return self::SEND_EMAIL_NEVER;
             case '1':

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -363,7 +363,12 @@ class LinkAnalyzer implements LoggerAwareInterface
                     // last_check reflects time of last check (may be older if URL was in cache)
                     $record['last_check_url'] = $linkTargetResponse->getLastChecked() ?: \time();
                     $record['last_check'] = \time();
-                    $this->brokenLinkRepository->insertOrUpdateBrokenLink($record);
+                    if ($this->brokenLinkRepository->insertOrUpdateBrokenLink($record)
+                        && $linkTargetResponse->isError()
+                    ) {
+                        // new broken link found
+                        $this->statistics->incrementNewBrokenLink();
+                    }
                 } elseif ($this->configuration->isShowAllLinks()) {
                     $record['check_status'] = $linkTargetResponse->getStatus();
                     $record['url_response'] = $linkTargetResponse->toJson();

--- a/Classes/Repository/BrokenLinkRepository.php
+++ b/Classes/Repository/BrokenLinkRepository.php
@@ -587,8 +587,9 @@ class BrokenLinkRepository implements LoggerAwareInterface
      * Update existing record or insert new
      *
      * @param mixed[] $record
+     * @return bool Returns true if new record was inserted
      */
-    public function insertOrUpdateBrokenLink(array $record): void
+    public function insertOrUpdateBrokenLink(array $record): bool
     {
         $queryBuilder = $this->generateQueryBuilder(self::TABLE);
         $count = (int)$queryBuilder->count('uid')
@@ -623,7 +624,9 @@ class BrokenLinkRepository implements LoggerAwareInterface
             $this->updateBrokenLink($record, $identifier);
         } else {
             $this->insertBrokenLink($record);
+            return true;
         }
+        return false;
     }
 
     /**

--- a/Configuration/TsConfig/Page/pagetsconfig.tsconfig
+++ b/Configuration/TsConfig/Page/pagetsconfig.tsconfig
@@ -80,8 +80,10 @@ mod.brofix {
   }
 
 	mail {
-	  # always send mail after checking links with command brofix:checklinks
-    sendOnCheckLinks = 1
+	  # if we should send mail after checking links with command brofix:checklinks
+	  # values: never | always | any | new
+	  # numeric values are deprecated, use strings
+    sendOnCheckLinks = always
     # should contain email address(es) of recipients
 	  recipients =
 	  # "From" name. If this is empty, $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromName']  is used

--- a/Documentation/Changelog/Entries/6.x/Feature-Make-configurable-when-to-send-email.rst
+++ b/Documentation/Changelog/Entries/6.x/Feature-Make-configurable-when-to-send-email.rst
@@ -17,8 +17,8 @@ The old values (0, 1, -1) are still supported and are mapped to the new values.
 * "**new**"   : send email if new broken links were found
 * "**auto**"  : do not override, use :ref:`TSconfig mail.sendOnCheckLinks <tsconfigSendOnCheckLinks>`
 
-If "auto" is used, the TSconfig will be used which makes it possible to configure
-this for each site individually.
+If "auto" is used, the TSconfig configuration will be used which makes it
+possible to configure this for each site individually.
 
 Migration
 =========

--- a/Documentation/Changelog/Entries/6.x/Feature-Make-configurable-when-to-send-email.rst
+++ b/Documentation/Changelog/Entries/6.x/Feature-Make-configurable-when-to-send-email.rst
@@ -1,0 +1,33 @@
+.. include:: /Includes.rst.txt
+
+=======================================================
+Feature - More configuration options for sending emails
+=======================================================
+
+There is an option "send-email" in the command / scheduler task which determined
+if an email should be sent when the link checking is complete. There are now
+more options which also make it possible to send an email only when broken
+links were found and also only when new broken links were found.
+
+The old values (0, 1, -1) are still supported and are mapped to the new values.
+
+* "**never**" : never send email (previously: 0)
+* "**always**": send email (previously: 1)
+* "**any**"   : send email if any broken links were found
+* "**new**"   : send email if new broken links were found
+* "**auto**"  : do not override, use :ref:`TSconfig mail.sendOnCheckLinks <tsconfigSendOnCheckLinks>`
+
+If "auto" is used, the TSconfig will be used which makes it possible to configure
+this for each site individually.
+
+Migration
+=========
+
+As the old values will still work, no change is necessary, but it is recommended
+to use the new string values instead of the old numeric values.
+
+Info
+====
+
+* :ref:`TSconfig mail.sendOnCheckLinks <tsconfigSendOnCheckLinks>`
+* :ref:`Command / scheduler option send-email <command_checklinks_send-email>`

--- a/Documentation/Setup/Commands.rst
+++ b/Documentation/Setup/Commands.rst
@@ -42,3 +42,25 @@ Execute link checking, send an email to `webmaster@example.org`:
 
     vendor/bin/typo3 brofix:checklinks --to webmaster@example.org
 
+Options
+-------
+
+Not all options are described here!
+
+.. _command_checklinks_send-email:
+
+-e / --send-email
+~~~~~~~~~~~~~~~~~
+
+Configure whether to send an email when link checking is complete. If "auto"
+is used (the default), this does not override the TSconfig setting. The
+TSconfig setting uses "always" by default. See
+:ref:`TSconfig option mail.sendOnCheckLinks <tsconfigSendOnCheckLinks>`
+for description of available values.
+
+Example:
+
+.. code-block:: shell
+
+   # send email only if broken links were found
+   vendor/bin/typo3 brofix:checklinks -e any

--- a/Documentation/Setup/TsconfigReference.rst
+++ b/Documentation/Setup/TsconfigReference.rst
@@ -713,14 +713,20 @@ mail.sendOnCheckLinks
       mod.brofix.mail.sendOnCheckLinks
 
    Data type
-      int
+      string
 
    Description
       Enable sending an email when the brofix:checkLinks console command
       is excecuted. This can be overridden via command line arguments (`-e`).
+      Possible values:
+
+      * "**never**" : never send email (previously: 0)
+      * "**always**": send email (previously: 1)
+      * "**any**"   : send email if any broken links were found
+      * "**new**"   : send email if new broken links were found
 
    Default
-      1
+      always
 
 
 .. _tsconfigMailRecipients:


### PR DESCRIPTION
There are 2 ways to influence if / when an email is sent after link checking via cli / scheduler

1. the option send-email (short: -e) in the cli / scheduler command
2. TSconfig mod.brofix.mail.sendOnCheckLinks

We now add some more options for better control when emails are sent:

* "**never**" : never send email (previously: 0)
* "**always**": send email (previously: 1)
* "**any**"   : send email if any broken links were found
* "**new**"   : send email if new broken links were found
* "**auto**"  : do not override, use TSconfig

Effectively, using the option in the command overrides the TSconfig configuration, unless "auto" is used.

If one wants to change the behaviour for each site individually, it is possible to configure this via TSconfig and run the command with -send-email auto.

See Changelog in the documentation for more information.

Resolves: #315