### PR TITLE
[BUGFIX] Add list_type to list of select fields if tt_content

### DIFF
--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -530,6 +530,7 @@ class LinkAnalyzer implements LoggerAwareInterface
         }
         if ($table === 'tt_content') {
             $defaultFields[] = 'colPos';
+            $defaultFields[] = 'list_type';
         }
         foreach ($selectFields as $field) {
             // field must have TCA configuration


### PR DESCRIPTION
This may prevent exception if processing flexform fields without using tcaProcessing = 'full'.

Processing Flexforms should still be performed with tcaProcessing ='full' though.