### PR TITLE
[BUGFIX] Fix extension configuration

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,20 +1,26 @@
-# cat=basic; type=bool; label=Do not use these softreference parsers (comma separated list) when parsing content (default: "url": workaround for TYPO3 core bug)
+### separate label and description with ":"
+### Things added in later versions, add at the bottom
+### Use category "checking" and "backend"
+
+# cat=checking; type=string; label=Do not use these softreference parsers (comma separated list) when parsing content: This is a workaround for a TYPO3 core bug. The default is "url".
 excludeSoftrefs = url
 
-# cat=basic; type=bool; label=In which fields should excludeSoftrefs apply (comma separated list of table.field) (default: tt_content.bodytext)
+# cat=checking; type=string; label=In which fields should excludeSoftrefs apply: This is a comma separated list of table.field. The default is "tt_content.bodytext".
 excludeSoftrefsInFields = tt_content.bodytext
 
-# cat=basic; type=int; label= Maximum number of pages to traverse in Backend. Limit is disabled if =0. This should be set to a hard limit for performance reasons.
-traverseMaxNumberOfPagesInBackend = 1000
-
-# cat=basic; type=bool; label=Show all links, not just broken links
-showalllinks = 1
-
-# cat=basic; type=bool; label=Non-checkable match: If check result matches this, link target is considered non-checkable, can be a regex if start with regex: or match start of, is errortype:errorcode:exception message
-combinedErrorNonCheckableMatch = regex:/^(httpStatusCode:(401|403):|libcurlErrno:60:SSL certificate problem: unable to get local issuer certificate)/
-
-# cat=basic; type=options[default=default,full=full]; label= Perform TCA processing (see documentation for details)
+# cat=checking; type=options[default=default,full=full]; label= How to perform TCA processing: Set this to "full" if Flexform fields should be processed. The default is "default".
 tcaProcessing = default
 
-# cat=basic; type=string; label= Override FormDataGroup for processing TCA (see documentation for details)
+# cat=checking; type=string; label= Override FormDataGroup for processing TCA: The default is empty which means use the FormDataGroup based on tcaProcessing setting.
 overrideFormDataGroup =
+
+# cat=backend; type=int; label= Maximum number of pages to traverse in Backend: Limit is disabled if =0. The default is 1000. This should be set to a hard limit for performance reasons.
+traverseMaxNumberOfPagesInBackend = 1000
+
+### since TYPO3 v12
+
+# cat=checking; type=bool; label=If an error code / type / exception matches this, the URL is non-checkable: This can be a regex if it starts with regex (separated by colon), otherwise it matches by start of string.
+combinedErrorNonCheckableMatch = regex:/^(httpStatusCode:(401|403):|libcurlErrno:60:SSL certificate problem: unable to get local issuer certificate)/
+
+# cat=backend; type=bool; label=Show all links, not just broken links: The default is 1 (true).
+showalllinks = 1


### PR DESCRIPTION
- Use only one colon (":") in the label to separate label from description
- Use categories to create multiple tabs
- Order the options so that options for newer versions are at the bottom (for easier backports)
- Add some better descriptions
- Add the default values