### PR TITLE
[TASK] Show time for last check URL and record again

### DIFF
--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -68,10 +68,10 @@ class BrokenLinkListController extends AbstractBrofixController
             ['table_name', 'DESC'],
             ['field', 'DESC'],
         ],
-        'last_check' => [
+        'last_check_url' => [
             ['last_check_url', 'ASC'],
         ],
-        'last_check_reverse' => [
+        'last_check_url_reverse' => [
             ['last_check_url', 'DESC'],
         ],
         'url' => [
@@ -734,10 +734,11 @@ class BrokenLinkListController extends AbstractBrofixController
             'page',
             'element',
             'type',
+            'last_check_record',
             'linktext',
             'url',
             'error',
-            'last_check',
+            'last_check_url',
             'action'
         ];
 
@@ -749,7 +750,17 @@ class BrokenLinkListController extends AbstractBrofixController
                 'url'   => '',
                 'icon'  => '',
             ];
-            $tableHeadData[$key]['label'] = $languageService->getLL('list.tableHead.' . $key);
+            if ($key === 'last_check_record') {
+                $tableHeadData[$key]['label'] = $languageService->getLL('list.tableHead.last_check')
+                . '<br/>'
+                . $languageService->getLL('list.tableHead.last_check.record');
+            } elseif ($key === 'last_check_url') {
+                $tableHeadData[$key]['label'] = $languageService->getLL('list.tableHead.last_check')
+                . '<br/>'
+                    . $languageService->getLL('list.tableHead.last_check.url');
+            } else {
+                $tableHeadData[$key]['label'] = $languageService->getLL('list.tableHead.' . $key);
+            }
             if (isset($sortActions[$key])) {
                 // sorting available, add url
                 if ($this->orderBy === $key) {
@@ -976,7 +987,9 @@ class BrokenLinkListController extends AbstractBrofixController
 
         // last check of record
         // show the oldest last_check, either for the record or for the link target
-        $variables['lastcheck'] = StringUtil::formatTimestampAsString($row['last_check'] < $row['last_check_url'] ? $row['last_check'] : $row['last_check_url']);
+        $variables['lastcheck_combined'] = StringUtil::formatTimestampAsString($row['last_check'] < $row['last_check_url'] ? $row['last_check'] : $row['last_check_url']);
+        $variables['last_check'] = StringUtil::formatTimestampAsString($row['last_check']);
+        $variables['last_check_url'] = StringUtil::formatTimestampAsString($row['last_check_url']);
 
         // determine if check is fresh or stale
         $tstamp_field = $GLOBALS['TCA'][$row['table_name']]['ctrl']['tstamp'] ?? '';

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -36,7 +36,13 @@
 				<source>Type</source>
 			</trans-unit>
 			<trans-unit id="list.tableHead.last_check" resname="list.tableHead.last_check">
-				<source>Checked</source>
+				<source>Last checked</source>
+			</trans-unit>
+			<trans-unit id="list.tableHead.last_check.url" resname="list.tableHead.last_check_url">
+				<source>(URL)</source>
+			</trans-unit>
+			<trans-unit id="list.tableHead.last_check.record" resname="list.tableHead.last_check_url">
+				<source>(record)</source>
 			</trans-unit>
 			<trans-unit id="list.tableHead.url" resname="list.tableHead.url">
 				<source>Link target</source>
@@ -46,9 +52,6 @@
 			</trans-unit>
 			<trans-unit id="list.tableHead.error" resname="list.tableHead.error">
 				<source>Error</source>
-			</trans-unit>
-			<trans-unit id="list.tableHead.last_check_url" resname="list.tableHead.last_check_url">
-				<source>Checked</source>
 			</trans-unit>
 			<trans-unit id="list.tableHead.action" resname="list.tableHead.action">
 				<source>Action</source>

--- a/Resources/Private/Templates/Backend/BrokenLinkList.html
+++ b/Resources/Private/Templates/Backend/BrokenLinkList.html
@@ -131,6 +131,14 @@
 							<core:icon identifier="{tableHeader.type.icon}"/>
 						</f:if>
 					</th>
+
+					<f:comment>=== Last checked (record) ===</f:comment>
+					<th class="mobile-optional">
+						<f:translate extensionName="brofix" key="LLL:EXT:brofix/Resource/Private/Language/Module/locallang.xlf:list.tableHead.last_check">Last checked</f:translate>
+						<br/>
+						<f:translate extensionName="brofix" key="LLL:EXT:brofix/Resource/Private/Language/Module/locallang.xlf:list.tableHead.last_check.record">(record)</f:translate>
+					</th>
+
 					<th>
 						<f:format.raw>{tableHeader.linktext.header}</f:format.raw>
 					</th>
@@ -146,12 +154,16 @@
 							<core:icon identifier="{tableHeader.error.icon}"/>
 						</f:if>
 					</th>
+
+					<f:comment>===Last checked URL ===</f:comment>
 					<th class="mobile-optional">
-						<f:format.raw> {tableHeader.last_check.header}</f:format.raw>
-						<f:if condition="{tableHeader.last_check.icon}">
-							<core:icon identifier="{tableHeader.last_check.icon}"/>
+						<f:format.raw> {tableHeader.last_check_url.header}</f:format.raw>
+						<f:if condition="{tableHeader.last_check_url.icon}">
+							<core:icon identifier="{tableHeader.last_check_url.icon}"/>
 						</f:if>
 						<br/>
+					</th>
+
 					<th>
 						{tableHeader.action.header}
 					</th>
@@ -196,6 +208,15 @@
 					<td class="mobile-optional">{item.elementIcon -> f:format.raw()}<span
 						title="{item.table} {item.field}">{item.elementType}:<br/>{item.fieldName}</span>
 					</td>
+
+					<f:comment>==== last_check (record) ====</f:comment>
+					<td class="mobile-optional" title="{f:translate(key: 'list.info.freshness.{item.freshness}', extensionName: 'Brofix')}">
+						<span class="freshness_{item.freshness}">{item.last_check}</span>
+						<f:if condition="{item.freshness} == 'stale'>">
+							<core:icon identifier="actions-document-synchronize"/>
+						</f:if>
+					</td>
+
 					<td>
 						<span>{item.link_title}</span>
 					</td>
@@ -221,12 +242,12 @@
 						</div>
 					</td>
 					<td>{item.linkmessage -> f:format.raw()}</td>
-					<td class="mobile-optional" title="{f:translate(key: 'list.info.freshness.{item.freshness}', extensionName: 'Brofix')}">
-						<span class="freshness_{item.freshness}">{item.lastcheck}</span>
-						<f:if condition="{item.freshness} == 'stale'>">
-							<core:icon identifier="actions-document-synchronize"/>
-						</f:if>
+
+					<f:comment>==== last_check_url ====</f:comment>
+					<td class="mobile-optional" title="">
+						<span>{item.last_check_url}</span>
 					</td>
+
 					<td>
 						<a class="btn btn-primary" href="{item.editUrl}"
 						   title="{f:translate(key: 'list.edit.field', extensionName: 'Brofix')}">


### PR DESCRIPTION
Previously we showed the last check time for URL and record separately. Since then, it was unified into one field but this can be confusing.

Because of the link target cache and how checking is performed, the last check time for the record and the URL may differ, so they should be shown separately.