### PR TITLE
[BUGFIX] Fix initialization of TYPO3_REQUEST in command

### DIFF
--- a/Classes/Command/CheckLinksCommand.php
+++ b/Classes/Command/CheckLinksCommand.php
@@ -472,12 +472,12 @@ class CheckLinksCommand extends Command
             /** @var LinkAnalyzer $linkAnalyzer */
             $linkAnalyzer = GeneralUtility::makeInstance(LinkAnalyzer::class);
             $linkAnalyzer->init($pageIds, $this->configuration);
-            if (isset($GLOBALS['REQUEST'])) {
-                $request = $GLOBALS['REQUEST'];
+            if (isset($GLOBALS['TYPO3_REQUEST'])) {
+                $request = $GLOBALS['TYPO3_REQUEST'];
             } else {
                 $request = CommandUtility::createFakeWebRequest($this->backendUri);
                 // set global variable here because it might be used by FormEngine processing (e.g. FormDataProvider, hooks etc.)
-                $GLOBALS['REQUEST'] = $request;
+                $GLOBALS['TYPO3_REQUEST'] = $request;
             }
             $linkAnalyzer->generateBrokenLinkRecords(
                 $request,


### PR DESCRIPTION
Since $GLOBALS['TYPO3_REQUEST'] may be used in some lowlevel TCA processing routines (e.g. in news), it is necessary to initialize this global variable. However, this was done incorrectly.