### PR TITLE
[FEATURE] Add button to edit entire record

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -58,6 +58,13 @@ class Configuration
     public const SEND_EMAIL_AVAILABLE_VALUES = [self::SEND_EMAIL_NEVER, self::SEND_EMAIL_ALWAYS, self::SEND_EMAIL_ANY,
         self::SEND_EMAIL_NEW, self::SEND_EMAIL_AUTO];
 
+    public const SHOW_EDIT_BUTTONS_EDIT_FIELD = 'field';
+    public const SHOW_EDIT_BUTTONS_EDIT_FULL = 'full';
+
+    public const SHOW_EDIT_BUTTONS_BOTH = 'both';
+
+    public const SHOW_EDIT_BUTTONS_DEFAULT_VALUE = self::SHOW_EDIT_BUTTONS_BOTH;
+
     public const TRAVERSE_MAX_NUMBER_OF_PAGES_IN_BACKEND_DEFAULT = 1000;
     public const DEFAULT_TSCONFIG = [
         'searchFields.' => [
@@ -163,6 +170,8 @@ class Configuration
 
     protected string $overrideFormDataGroup = '';
 
+    protected string $showEditButtons = self::SEND_EMAIL_DEFAULT_VALUE;
+
     /**
      * Configuration constructor.
      * @param array<mixed> $extConfArray ExtensionConfiguration array
@@ -171,6 +180,7 @@ class Configuration
     {
         // initialize from extension configuration
         $this->showAllLinks = (bool)($extConfArray['showalllinks'] ?? true);
+        $this->showEditButtons = ($extConfArray['showEditButtons'] ?? self::SHOW_EDIT_BUTTONS_DEFAULT_VALUE);
         $this->combinedErrorNonCheckableMatch = $extConfArray['combinedErrorNonCheckableMatch'] ?? '';
         $this->excludeSoftrefs = explode(',', $extConfArray['excludeSoftrefs'] ?? '');
         $this->excludeSoftrefsInFields = explode(',', $extConfArray['excludeSoftrefsInFields'] ?? '');
@@ -697,6 +707,16 @@ class Configuration
     public function getExcludeSoftrefsInFields(): array
     {
         return $this->excludeSoftrefsInFields;
+    }
+
+    public function getShowEditButtons(): string
+    {
+        return $this->showEditButtons;
+    }
+
+    public function setShowEditButtons(string $showEditButtons): void
+    {
+        $this->showEditButtons = $showEditButtons;
     }
 
     public function isShowAllLinks(): bool

--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -778,15 +778,24 @@ class BrokenLinkListController extends AbstractBrofixController
          * @var UriBuilder $uriBuilder
          */
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-        $variables['editUrl'] = (string)$uriBuilder->buildUriFromRoute('record_edit', [
+        $showEditButtons = $this->configuration->getShowEditButtons();
+        $editUrlParameters = [
             'edit' => [
                 $table => [
-                    $row['record_uid'] => 'edit'
-                ]
+                    $row['record_uid'] => 'edit',
+                ],
             ],
-            'columnsOnly' => $row['field'],
-            'returnUrl' => $backUriEditField
-        ]);
+            'returnUrl' => $backUriEditField,
+        ];
+        if ($showEditButtons === 'both' || $showEditButtons === 'full') {
+            // Construct link to edit the full record
+            $variables['editUrlFull'] = (string)$uriBuilder->buildUriFromRoute('record_edit', $editUrlParameters);
+        }
+        if ($showEditButtons === 'both' || $showEditButtons === 'field') {
+            // Construct link to edit the field
+            $editUrlParameters['columnsOnly'] = $row['field'];
+            $variables['editUrlField'] = (string)$uriBuilder->buildUriFromRoute('record_edit', $editUrlParameters);
+        }
 
         // construct URL to recheck the URL
         $variables['recheckUrl'] = $this->constructBackendUri(

--- a/Documentation/Changelog/Entries/6.x/Features-Make-it-possible-to-edit-full-record.rst
+++ b/Documentation/Changelog/Entries/6.x/Features-Make-it-possible-to-edit-full-record.rst
@@ -1,0 +1,38 @@
+.. include:: /Includes.rst.txt
+
+.. _feature-352:
+
+=============================================================
+Feature: issue 352 - Make it possible to edit the full record
+=============================================================
+
+See
+
+* core :issue:`103493`
+* brofix issue https://github.com/sypets/brofix/issues/352
+
+Description
+===========
+
+Previously, a form showing only the field with the broken link is opened, if
+clicking the "pencil" button in the Broken Link Fixer report.
+
+This is not ideal in some cases because relevant context is missing, for example
+when editing redirect records.
+
+For this reason, it is now possible to also edit the full record, but this is
+configurable (see Extension Configuration).
+
+
+Impact
+======
+
+A new button is now displayed in the broken link list BE module, in addition to the
+already existing button. The buttons have the following functionality:
+
+1. button to edit only the field (same as before)
+2. button to edit the entire record (which contains an additional icon)
+
+If this makes sense depends on which records / fields are checked and if it is
+helpful to have more context. If not, this can be deactivated in the Extension
+Configuration.

--- a/Documentation/Setup/ExtensionConfigurationReference.rst
+++ b/Documentation/Setup/ExtensionConfigurationReference.rst
@@ -219,6 +219,23 @@ available values:
 
 Changes how the TCA processing is done.
 
+
+.. _extensionConfiguation_brofix_showEditButtons:
+
+EXT:brofix | showEditButtons
+----------------------------
+
+(since TYPO3 v12)
+
+*Show button to edit entire record, only the field with a broken link or both.*
+
+:guilabel:`Backend` tab
+
+default:
+   "Both" (both buttons are displayed)
+available values:
+   "Both", "Edit field", "Edit full"
+
 .. _extensionConfiguation_brofix_showalllinks:
 
 EXT:brofix | showalllinks

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -103,6 +103,9 @@
 			<trans-unit id="list.edit.field" resname="list.edit.field">
 				<source>Edit field containing this broken link</source>
 			</trans-unit>
+			<trans-unit id="list.edit.record" resname="list.edit.record">
+				<source>Edit entire element containing this broken link</source>
+			</trans-unit>
 			<trans-unit id="list.action.recheckUrl" resname="list.action.recheckUrl">
 				<source>Check link again</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_extconf.xlf
+++ b/Resources/Private/Language/locallang_extconf.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:brofix/Resources/Private/Language/locallang_extconf.xlf" date="2024-04-07T10:22:34Z" product-name="brofix">
+		<header/>
+		<body>
+			<trans-unit id="showEditButtons" resname="showEditButtons">
+				<source>Show button to edit entire record, only the field with a broken link or both.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Partials/BrokenLinkList.html
+++ b/Resources/Private/Partials/BrokenLinkList.html
@@ -140,10 +140,18 @@
 					<span>{item.last_check_url}</span>
 				</td>
 				<td>
-					<a class="btn btn-primary" href="{item.editUrl}"
-					   title="{f:translate(key: 'list.edit.field', extensionName: 'Brofix')}">
-						<core:icon identifier="actions-open" size="small"/>
-					</a>
+					<f:if condition="{item.editUrlField}">
+						<a class="btn btn-primary" href="{item.editUrlField}"
+						   title="{f:translate(key: 'list.edit.field', extensionName: 'Brofix')}">
+							<core:icon identifier="actions-open" size="small"/>
+						</a>
+					</f:if>
+					<f:if condition="{item.editUrlFull}">
+						<a class="btn btn-primary" href="{item.editUrlFull}"
+						   title="{f:translate(key: 'list.edit.record', extensionName: 'Brofix')}">
+							<core:icon identifier="form-content-element" size="small"/><core:icon identifier="actions-open" size="small"/>
+						</a>
+					</f:if>
 					<f:if condition="{item.recheckUrl}">
 						<a title="{f:translate(key: 'list.action.recheckUrl', extensionName='Brofix')}"
 						   class="btn btn-default" href="{item.recheckUrl}">

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -23,6 +23,9 @@ linkTargetCacheExpiresLow = 0
 # cat=checking; type=int; label= External link target cache (in seconds) for rechecking in Backend: Default value is 0, which means use TSconfig value linkTargetCache.expiresHigh
 linkTargetCacheExpiresHigh = 0
 
+# cat=backend; type=options[Both=both, Edit field=field, Edit full=full]; label=LLL:EXT:brofix/Resources/Private/Language/locallang_extconf.xlf:showEditButtons
+showEditButtons = both
+
 ### since TYPO3 v12
 
 # cat=checking; type=bool; label=If an error code / type / exception matches this, the URL is non-checkable: This can be a regex if it starts with regex (separated by colon), otherwise it matches by start of string.


### PR DESCRIPTION
Previously, there was a button in the link list to edit the field where the broken link is contained. It is now possible - via extension configuration - to show:

- only button to edit the field
- button to edit entire record (element)
- or both

In some cases, e.g. for sys_redirect records it is helpful to have more context and edit the entire record.

Resolves: #352