### PR TITLE
[FEATURE] Add button to edit entire record

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -58,6 +58,13 @@ class Configuration
     public const SEND_EMAIL_AVAILABLE_VALUES = [self::SEND_EMAIL_NEVER, self::SEND_EMAIL_ALWAYS, self::SEND_EMAIL_ANY,
         self::SEND_EMAIL_NEW, self::SEND_EMAIL_AUTO];
 
+    public const SHOW_EDIT_BUTTONS_EDIT_FIELD = 'field';
+    public const SHOW_EDIT_BUTTONS_EDIT_FULL = 'full';
+
+    public const SHOW_EDIT_BUTTONS_BOTH = 'both';
+
+    public const SHOW_EDIT_BUTTONS_DEFAULT_VALUE = self::SHOW_EDIT_BUTTONS_BOTH;
+
     public const TRAVERSE_MAX_NUMBER_OF_PAGES_IN_BACKEND_DEFAULT = 1000;
 
     public const DEFAULT_TSCONFIG = [
@@ -158,6 +165,13 @@ class Configuration
 
     protected string $overrideFormDataGroup = '';
 
+    protected string $showEditButtons = self::SEND_EMAIL_DEFAULT_VALUE;
+
+    /** Show all links, not just the broken links */
+    protected bool $showAllLinks = true;
+
+    protected string $combinedErrorNonCheckableMatch = 'regex:/^httpStatusCode:(401|403):/';
+
     /**
      * Configuration constructor.
      * @param array<mixed> $extConfArray
@@ -165,6 +179,9 @@ class Configuration
     public function __construct(array $extConfArray)
     {
         // initialize from extension configuration
+        $this->showAllLinks = (bool)($extConfArray['showalllinks'] ?? true);
+        $this->showEditButtons = ($extConfArray['showEditButtons'] ?? self::SHOW_EDIT_BUTTONS_DEFAULT_VALUE);
+        $this->combinedErrorNonCheckableMatch = $extConfArray['combinedErrorNonCheckableMatch'] ?? '';
         $this->excludeSoftrefs = explode(',', $extConfArray['excludeSoftrefs'] ?? '');
         $this->excludeSoftrefsInFields = explode(',', $extConfArray['excludeSoftrefsInFields'] ?? '');
         $this->setTraverseMaxNumberOfPagesInBackend(
@@ -690,6 +707,31 @@ class Configuration
     public function getExcludeSoftrefsInFields(): array
     {
         return $this->excludeSoftrefsInFields;
+    }
+
+    public function getShowEditButtons(): string
+    {
+        return $this->showEditButtons;
+    }
+
+    public function setShowEditButtons(string $showEditButtons): void
+    {
+        $this->showEditButtons = $showEditButtons;
+    }
+
+    public function isShowAllLinks(): bool
+    {
+        return $this->showAllLinks;
+    }
+
+    public function setShowAllLinks(bool $showAllLinks): void
+    {
+        $this->showAllLinks = $showAllLinks;
+    }
+
+    public function getCombinedErrorNonCheckableMatch(): string
+    {
+        return $this->combinedErrorNonCheckableMatch;
     }
 
     public function getTcaProcessing(): string

--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -845,15 +845,24 @@ class BrokenLinkListController extends AbstractBrofixController
          * @var UriBuilder $uriBuilder
          */
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-        $variables['editUrl'] = (string)$uriBuilder->buildUriFromRoute('record_edit', [
+        $showEditButtons = $this->configuration->getShowEditButtons();
+        $editUrlParameters = [
             'edit' => [
                 $table => [
-                    $row['record_uid'] => 'edit'
-                ]
+                    $row['record_uid'] => 'edit',
+                ],
             ],
-            'columnsOnly' => $row['field'],
-            'returnUrl' => $backUriEditField
-        ]);
+            'returnUrl' => $backUriEditField,
+        ];
+        if ($showEditButtons === 'both' || $showEditButtons === 'full') {
+            // Construct link to edit the full record
+            $variables['editUrlFull'] = (string)$uriBuilder->buildUriFromRoute('record_edit', $editUrlParameters);
+        }
+        if ($showEditButtons === 'both' || $showEditButtons === 'field') {
+            // Construct link to edit the field
+            $editUrlParameters['columnsOnly'] = $row['field'];
+            $variables['editUrlField'] = (string)$uriBuilder->buildUriFromRoute('record_edit', $editUrlParameters);
+        }
 
         // construct URL to recheck the URL
         $variables['recheckUrl'] = $this->constructBackendUri(

--- a/Documentation/Changelog/Entries/6.x/Features-Make-it-possible-to-edit-full-record.rst
+++ b/Documentation/Changelog/Entries/6.x/Features-Make-it-possible-to-edit-full-record.rst
@@ -1,0 +1,38 @@
+.. include:: /Includes.rst.txt
+
+.. _feature-352:
+
+=============================================================
+Feature: issue 352 - Make it possible to edit the full record
+=============================================================
+
+See
+
+* core :issue:`103493`
+* brofix issue https://github.com/sypets/brofix/issues/352
+
+Description
+===========
+
+Previously, a form showing only the field with the broken link is opened, if
+clicking the "pencil" button in the Broken Link Fixer report.
+
+This is not ideal in some cases because relevant context is missing, for example
+when editing redirect records.
+
+For this reason, it is now possible to also edit the full record, but this is
+configurable (see Extension Configuration).
+
+
+Impact
+======
+
+A new button is now displayed in the broken link list BE module, in addition to the
+already existing button. The buttons have the following functionality:
+
+1. button to edit only the field (same as before)
+2. button to edit the entire record (which contains an additional icon)
+
+If this makes sense depends on which records / fields are checked and if it is
+helpful to have more context. If not, this can be deactivated in the Extension
+Configuration.

--- a/Documentation/Setup/ExtensionConfigurationReference.rst
+++ b/Documentation/Setup/ExtensionConfigurationReference.rst
@@ -157,6 +157,42 @@ available values:
 
 Changes how the TCA processing is done.
 
+.. _extensionConfiguation_brofix_showEditButtons:
+
+EXT:brofix | showEditButtons
+----------------------------
+
+(since TYPO3 v12)
+
+*Show button to edit entire record, only the field with a broken link or both.*
+
+:guilabel:`Backend` tab
+
+default:
+   "Both" (both buttons are displayed)
+available values:
+   "Both", "Edit field", "Edit full"
+
+.. _extensionConfiguation_brofix_showalllinks:
+
+EXT:brofix | showalllinks
+----------------------------------------------
+
+(since TYPO3 v12)
+
+*Show all links, not just broken links.*
+
+:guilabel:`Backend` tab
+
+default:
+   1 (on)
+available values:
+   1 (on) | 0 (off)
+
+If this is on, all links can be displayed, not just the broken links. This
+requires a full recheck if the setting was previously off or the feature not
+yet available.
+
 .. _extensionConfiguation_brofix_traverseMaxNumberOfPagesInBackend:
 
 EXT:brofix | traverseMaxNumberOfPagesInBackend

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -95,6 +95,9 @@
 			<trans-unit id="list.edit.field" resname="list.edit.field">
 				<source>Edit field containing this broken link</source>
 			</trans-unit>
+			<trans-unit id="list.edit.record" resname="list.edit.record">
+				<source>Edit entire element containing this broken link</source>
+			</trans-unit>
 			<trans-unit id="list.action.recheckUrl" resname="list.action.recheckUrl">
 				<source>Check link again</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_extconf.xlf
+++ b/Resources/Private/Language/locallang_extconf.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:brofix/Resources/Private/Language/locallang_extconf.xlf" date="2024-04-07T10:22:34Z" product-name="brofix">
+		<header/>
+		<body>
+			<trans-unit id="showEditButtons" resname="showEditButtons">
+				<source>Show button to edit entire record, only the field with a broken link or both.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Partials/BrokenLinkList.html
+++ b/Resources/Private/Partials/BrokenLinkList.html
@@ -140,10 +140,18 @@
 					<span>{item.last_check_url}</span>
 				</td>
 				<td>
-					<a class="btn btn-primary" href="{item.editUrl}"
-					   title="{f:translate(key: 'list.edit.field', extensionName: 'Brofix')}">
-						<core:icon identifier="actions-open" size="small"/>
-					</a>
+					<f:if condition="{item.editUrlField}">
+						<a class="btn btn-primary" href="{item.editUrlField}"
+						   title="{f:translate(key: 'list.edit.field', extensionName: 'Brofix')}">
+							<core:icon identifier="actions-open" size="small"/>
+						</a>
+					</f:if>
+					<f:if condition="{item.editUrlFull}">
+						<a class="btn btn-primary" href="{item.editUrlFull}"
+						   title="{f:translate(key: 'list.edit.record', extensionName: 'Brofix')}">
+							<core:icon identifier="form-content-element" size="small"/><core:icon identifier="actions-open" size="small"/>
+						</a>
+					</f:if>
 					<f:if condition="{item.recheckUrl}">
 						<a title="{f:translate(key: 'list.action.recheckUrl', extensionName='Brofix')}"
 						   class="btn btn-default" href="{item.recheckUrl}">

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -22,3 +22,14 @@ linkTargetCacheExpiresLow = 0
 
 # cat=checking; type=int; label= External link target cache (in seconds) for rechecking in Backend: Default value is 0, which means use TSconfig value linkTargetCache.expiresHigh
 linkTargetCacheExpiresHigh = 0
+
+# cat=backend; type=options[Both=both, Edit field=field, Edit full=full]; label=LLL:EXT:brofix/Resources/Private/Language/locallang_extconf.xlf:showEditButtons
+showEditButtons = both
+
+### since TYPO3 v12
+
+# cat=checking; type=bool; label=If an error code / type / exception matches this, the URL is non-checkable: This can be a regex if it starts with regex (separated by colon), otherwise it matches by start of string.
+combinedErrorNonCheckableMatch = regex:/^(httpStatusCode:(401|403):|libcurlErrno:60:SSL certificate problem: unable to get local issuer certificate)/
+
+# cat=backend; type=bool; label=Show all links, not just broken links: The default is 1 (true).
+showalllinks = 1


### PR DESCRIPTION
Previously, there was a button in the link list to edit the field where the broken link is contained. It is now possible - via extension configuration - to show:

- only button to edit the field
- button to edit entire record (element)
- or both

In some cases, e.g. for sys_redirect records it is helpful to have more context and edit the entire record.

Resolves: #352