### PR TITLE
[FEATURE] Make it possible to show links independently of pages

### DIFF
--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -54,9 +54,9 @@ class LinkAnalyzer implements LoggerAwareInterface
     /**
      * List of page uids (rootline downwards)
      *
-     * @var array<string|int>
+     * @var array<string|int>|null
      */
-    protected array $pids = [];
+    protected ?array $pids = [];
 
     protected ?Configuration $configuration = null;
     protected BrokenLinkRepository $brokenLinkRepository;
@@ -82,10 +82,10 @@ class LinkAnalyzer implements LoggerAwareInterface
     }
 
     /**
-     * @param array<string|int> $pidList
+     * @param array<string|int>|null $pidList (List of pids or null to not use pids)
      * @param Configuration $configuration
      */
-    public function init(array $pidList, Configuration $configuration): void
+    public function init(?array $pidList, Configuration $configuration): void
     {
         $this->configuration = $configuration;
 

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -75,6 +75,10 @@
 				<source>Simplified view</source>
 			</trans-unit>
 
+			<trans-unit id="labels.depth_all" resname="labels.depth_all">
+				<source>All</source>
+			</trans-unit>
+
 			<!-- filter -->
 			<trans-unit id="list.filter.uid" resname="list.filter.uid">
 				<source>UID</source>

--- a/Resources/Private/Partials/BrokenLinksForm.html
+++ b/Resources/Private/Partials/BrokenLinksForm.html
@@ -31,6 +31,11 @@
 				<option value="999" {f:if(condition:'{depth} == 999', then: 'selected')}>
 				<f:translate extensionName="Brofix" key="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.depth_infi"/>
 				</option>
+				<f:if condition="{isAdmin}">
+					<option value="-1" {f:if(condition:'{depth} == -1', then: 'selected')}>
+					<f:translate extensionName="Brofix" key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:labels.depth_all"/>
+					</option>
+				</f:if>
 			</select>
 		</div>
 		<div class="col">
@@ -119,7 +124,7 @@
 		<button type="button" class="btn btn-default" id="brofix-reset-filter">
 			<f:translate extensionName="Brofix" key="button-remove-all-filter">Remove all filter</f:translate>
 		</button>
-		<f:if condition="{showRecheckButton}">
+		<f:if condition="{showRecheckButton} && {depth} != -1">
 			<button type="submit" class="btn btn-default t3js-update-button" name="action" id="updateLinkList"
 				   value="checklinks"
 				   data-notification-message="{f:translate(key: 'list.action.checkLinks', extensionName: 'Brofix')}">


### PR DESCRIPTION
If a user is admin user, it is now possible to show all broken links, regardless of currently selected page and depth.

This has mostly performance advantages - it is not necessary to iterate through the list of pages.

However, it should be made certain that only relevant broken links are in the table, e.g. not links for deleted or hidden pages.