### PR TITLE
[BUGFIX] Fix array access in EditableRestriction

### DIFF
--- a/Classes/Repository/EditableRestriction.php
+++ b/Classes/Repository/EditableRestriction.php
@@ -101,7 +101,10 @@ class EditableRestriction implements QueryRestrictionInterface
     protected function getExplicitAllowFieldsForCurrentUser(string $table, string $field): array
     {
         $allowDenyOptions = [];
-        $fieldConfig = $GLOBALS['TCA'][$table]['columns'][$field]['config'];
+        $fieldConfig = $GLOBALS['TCA'][$table]['columns'][$field]['config'] ?? [];
+        if (!$fieldConfig) {
+            return [];
+        }
         // Check for items
         if ($fieldConfig['type'] === 'select' && is_array($fieldConfig['items'] ?? false)) {
             foreach ($fieldConfig['items'] as $iVal) {


### PR DESCRIPTION
Do some checking before accessing fields in TCA in EditableRestriction. In particular, $GLOBALS['TCA'][$table]['ctrl']['type'] may contain a type which does not correspond to a field (such as 'uid_local:type' for sys_file_reference.

Fixing this makes it possible to add sys_file_reference to list of tables to check, e.g.

mod.brofix.searchFields.sys_file_reference = link

Resolves: #358