### PR TITLE
[FEATURE] Jump to page layout in correct language

### DIFF
--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -931,8 +931,12 @@ class BrokenLinkListController extends AbstractBrofixController
         $variables['elementIcon'] = $this->iconFactory->getIconForRecord($table, $row, Icon::SIZE_SMALL)->render();
 
         // langIcon
-        if (isset($row['language']) && $row['language'] != -1 && isset($this->siteLanguages[(int)($row['language'])])) {
-            $variables['langIcon'] = $this->siteLanguages[(int)($row['language'])]->getFlagIdentifier();
+        if (isset($row['language'])) {
+            $lang = (int)$row['language'];
+            if ($lang != -1 && isset($this->siteLanguages[$lang])) {
+                $variables['langIcon'] = $this->siteLanguages[$lang]->getFlagIdentifier();
+            }
+            $variables['lang'] = $lang;
         }
 
         // Element Type + Field

--- a/Resources/Private/Partials/BrokenLinkList.html
+++ b/Resources/Private/Partials/BrokenLinkList.html
@@ -155,7 +155,7 @@
 					</f:if>
 
 					<f:if condition="{showPageLayoutButton}">
-						<f:variable name="link"><be:moduleLink route="web_layout" arguments="{id: item.pageId, returnUrl: listUri}">layout</be:moduleLink></f:variable>
+						<f:variable name="link"><be:moduleLink route="web_layout" arguments="{id: item.pageId, returnUrl: listUri, 'SET[language]': item.lang}"></be:moduleLink></f:variable>
 						<a href="{link}" class="btn btn-default" title="page layout">
 							<core:icon identifier="actions-document" size="small"/>
 						</a>


### PR DESCRIPTION
In the link list, there is a button to jump to the page layout. This will now open the page layout in the current language of the record containing the broken link.