### PR TITLE
[BUGFIX] Better handling of type/authMode with permission checks

### DIFF
--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -348,7 +348,8 @@ class LinkAnalyzer implements LoggerAwareInterface
                 $record['flexform_field'] = $entryValue['flexformField'] ?? '';
                 $record['flexform_field_label'] = $entryValue['flexformFieldLabel'] ?? '';
                 $typeField = $GLOBALS['TCA'][$table]['ctrl']['type'] ?? false;
-                if ($entryValue['row'][$typeField] ?? false) {
+                // type might be '0', e.g. for tx_news_domain_model_news, so use isset instead of if with ??
+                if (isset($entryValue['row'][$typeField])) {
                     $record['element_type'] = $entryValue['row'][$typeField];
                 }
                 $record['exclude_link_targets_pid'] = $this->configuration->getExcludeLinkTargetStoragePid();


### PR DESCRIPTION
- always write the type to element_type, if available
- only use $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'] for tt_content, otherwise use $GLOBALS['TCA'][$table]['columns'][$type]['config']['authMode']
- if no autMode is set, do not add any checks for it to EditableRestriction

This should fix a known problem, that broken links in tx_domain_model_news records were not displayed for non-admin editors

Resolves: #369