### PR TITLE
[BUGFIX] Fix checken for broken link in EventListener

### DIFF
--- a/Classes/Repository/BrokenLinkRepository.php
+++ b/Classes/Repository/BrokenLinkRepository.php
@@ -517,7 +517,8 @@ class BrokenLinkRepository implements LoggerAwareInterface
                 ->from(static::TABLE)
                 ->where(
                     $queryBuilder->expr()->eq('url', $queryBuilder->createNamedParameter($linkTarget)),
-                    $queryBuilder->expr()->eq('link_type', $queryBuilder->createNamedParameter($linkType))
+                    $queryBuilder->expr()->eq('link_type', $queryBuilder->createNamedParameter($linkType)),
+                    $queryBuilder->expr()->eq('check_status', $queryBuilder->createNamedParameter(LinkTargetResponse::RESULT_BROKEN, \PDO::PARAM_INT))
                 );
             return (bool)$queryBuilder
                 ->executeQuery()


### PR DESCRIPTION
Since TYPO3 v6, a check_status was introduced to store various link checking results in the database (not just the broken links). This must now be checked as well.

The bug manifested itself in the RTE, where all links were shown as broken.