### PR TITLE
Fix Event triggered message

### DIFF
--- a/Resources/Public/JavaScript/Backend/Modules/Brofix.js
+++ b/Resources/Public/JavaScript/Backend/Modules/Brofix.js
@@ -57,11 +57,7 @@ class Brofix {
 
     $('.t3js-update-button').on('click', function() {
       var $element = $(this);
-      var name = $element.attr('name');
-      var message = 'Event triggered';
-      if (name === 'refreshLinkList' || name === 'updateLinkList') {
-        message = $element.data('notification-message');
-      }
+      var message = $element.data('notification-message');
       top.TYPO3.Notification.success(message);
     });
 

--- a/Resources/Public/JavaScript/Brofix.js
+++ b/Resources/Public/JavaScript/Brofix.js
@@ -75,11 +75,7 @@ define(['jquery'], function($) {
 
     $('.t3js-update-button').on('click', function() {
       var $element = $(this);
-      var name = $element.attr('name');
-      var message = 'Event triggered';
-      if (name === 'refreshLinkList' || name === 'updateLinkList') {
-        message = $element.data('notification-message');
-      }
+      var message = $element.data('notification-message');
       top.TYPO3.Notification.success(message);
     });
   };


### PR DESCRIPTION
Fixed bug details : 
Typo3 Version : 12.4.16
Clicking on the "Check Links" button displays the "Event triggered" alert message. This message is hardcoded and appears to be an error after analyzing the JavaScript code. I believe the intended message should be: "Checking links. This may take a while".
This PR aims to fix this bug.

![eventTriggered](https://github.com/user-attachments/assets/9b00ae28-b4d3-405b-8d66-ba0fffc781df)


