### PR TITLE
[FEATURE] Handle HTTP status code 429 and 503

### DIFF
--- a/Classes/CheckLinks/LinkTargetResponse/LinkTargetResponse.php
+++ b/Classes/CheckLinks/LinkTargetResponse/LinkTargetResponse.php
@@ -25,6 +25,9 @@ class LinkTargetResponse
 
     public const REASON_CANNOT_CHECK_CLOUDFLARE = 'cloudflare';
 
+    public const REASON_CANNOT_CHECK_429 = '429:too many requests';
+    public const REASON_CANNOT_CHECK_503 = '503:service unavailable';
+
     protected int $status;
     protected int $lastChecked = 0;
 

--- a/Tests/Unit/CheckLinks/CrawlDelayTest.php
+++ b/Tests/Unit/CheckLinks/CrawlDelayTest.php
@@ -41,12 +41,21 @@ class CrawlDelayTest extends AbstractUnit
     /**
      * @test
      */
-    public function crawlDelayDoesNotDelayForNewDomain(): void
+    public function crawlDelayReturnsTrueForNewDomain(): void
     {
         $subject = $this->initializeCrawlDelay();
         $subject->setConfiguration($this->configuration);
         $result = $subject->crawlDelay('example.org');
-        self::assertEquals(0, $result, 'Result should be 0 (no crawl delay)');
+        self::assertTrue($result, 'Result should be true');
+    }
+
+    public function crawlDelayNoWaitTimeForNewDomain(): void
+    {
+        $subject = $this->initializeCrawlDelay();
+        $subject->setConfiguration($this->configuration);
+        $subject->crawlDelay('example.org');
+        $result = $subject->getLastWaitSeconds();
+        self::assertEquals(0, $result, 'Result should be 0');
     }
 
     /**
@@ -60,7 +69,8 @@ class CrawlDelayTest extends AbstractUnit
         $subject = $this->initializeCrawlDelay();
         $subject->setConfiguration($this->configuration);
         $subject->crawlDelay('example.org');
-        $result = $subject->crawlDelay('example.com');
+        $subject->crawlDelay('example.com');
+        $result = $subject->getLastWaitSeconds();
         self::assertEquals(0, $result, 'Result should be 0 (no crawl delay)');
     }
 
@@ -78,7 +88,8 @@ class CrawlDelayTest extends AbstractUnit
         $expected = $this->configuration->getCrawlDelaySeconds();
 
         $subject->crawlDelay($domain);
-        $result = $subject->crawlDelay($domain);
+        $subject->crawlDelay($domain);
+        $result = $subject->getLastWaitSeconds();
         self::assertEquals(
             $expected,
             $result,


### PR DESCRIPTION
If status code 429 ("Too many requests") or 403 ("Service unavailable") is returned, we should stop checking URLs for this domain.

Additionally, the header "Retry-After" is handled.

The URLs are marked as "Cannot check".

Resolves: #420