### PR TITLE
[FEATURE] The redirect target is now displayed (if there are redirects)

### DIFF
--- a/Classes/CheckLinks/LinkTargetResponse/LinkTargetResponse.php
+++ b/Classes/CheckLinks/LinkTargetResponse/LinkTargetResponse.php
@@ -40,6 +40,8 @@ class LinkTargetResponse
 
     protected string $reasonCannotCheck = '';
 
+    protected array $redirects = [];
+
     /**
      * @param int $status
      * @param int $lastChecked
@@ -108,7 +110,7 @@ class LinkTargetResponse
      */
     public static function createInstanceFromArray(array $values): LinkTargetResponse
     {
-        return new LinkTargetResponse(
+        $linkTargetResponse = new LinkTargetResponse(
             $values['status'],
             $values['lastChecked'] ?? \time(),
             $values['custom'] ?? [],
@@ -118,6 +120,10 @@ class LinkTargetResponse
             $values['message'] ?? '',
             $values['reasonCannotCheck'] ?? ''
         );
+        if ($values['redirects'] ?? false) {
+            $linkTargetResponse->setRedirects($values['redirects'] ?? []);
+        }
+        return $linkTargetResponse;
     }
 
     /**
@@ -273,4 +279,30 @@ class LinkTargetResponse
         }
         return $result;
     }
+
+    public function getEffectiveUrl(): string
+    {
+        if ($this->redirects) {
+            return(string)( end($this->redirects)['to'] ?? '');
+        }
+        return '';
+
+    }
+
+    public function setRedirects(array $redirects): void
+    {
+        $this->redirects = $redirects;
+
+    }
+
+    public function getRedirects(): array
+    {
+        return $this->redirects;
+    }
+
+    public function getRedirectCount(): int
+    {
+        return count($this->redirects);
+    }
+
 }

--- a/Classes/CheckLinks/LinkTargetResponse/LinkTargetResponse.php
+++ b/Classes/CheckLinks/LinkTargetResponse/LinkTargetResponse.php
@@ -40,6 +40,9 @@ class LinkTargetResponse
 
     protected string $reasonCannotCheck = '';
 
+    /**
+     * @var array<int,array{from:string, to:string}>
+     */
     protected array $redirects = [];
 
     /**
@@ -283,18 +286,22 @@ class LinkTargetResponse
     public function getEffectiveUrl(): string
     {
         if ($this->redirects) {
-            return(string)( end($this->redirects)['to'] ?? '');
+            return(string)(end($this->redirects)['to'] ?? '');
         }
         return '';
-
     }
 
+    /**
+     * @param array<int,array{from:string, to:string}> $redirects
+     */
     public function setRedirects(array $redirects): void
     {
         $this->redirects = $redirects;
-
     }
 
+    /**
+     * @return array<int,array{from:string, to:string}>
+     */
     public function getRedirects(): array
     {
         return $this->redirects;
@@ -304,5 +311,4 @@ class LinkTargetResponse
     {
         return count($this->redirects);
     }
-
 }

--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -1014,6 +1014,8 @@ class BrokenLinkListController extends AbstractBrofixController
 
         // link / URL
         $variables['linktarget'] = $hookObj->getBrokenUrl($row);
+        $variables['effectiveUrl'] = $linkTargetResponse->getEffectiveUrl();
+        $variables['redirectCount'] = $linkTargetResponse->getRedirectCount();
         $variables['orig_linktarget'] = $row['url'];
         if ($this->filter->getUrlFilter() == $variables['orig_linktarget']
             && $this->filter->getUrlFilterMatch() === 'exact'

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -352,9 +352,8 @@ class LinkAnalyzer implements LoggerAwareInterface
                 if (!$linkTargetResponse) {
                     $this->debug("checkLinks: after checking $url: returned null, no checking for this URL");
                     continue;
-                } else {
-                    $this->debug("checkLinks: after checking $url");
                 }
+                $this->debug("checkLinks: after checking $url");
 
                 $this->statistics->incrementCountLinksByStatus($linkTargetResponse->getStatus());
 

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -349,7 +349,12 @@ class LinkAnalyzer implements LoggerAwareInterface
                 $this->debug("checkLinks: before checking $url");
                 /** @var LinkTargetResponse $linkTargetResponse */
                 $linkTargetResponse = $linktypeObject->checkLink((string)$url, $entryValue, $mode);
-                $this->debug("checkLinks: after checking $url");
+                if (!$linkTargetResponse) {
+                    $this->debug("checkLinks: after checking $url: returned null, no checking for this URL");
+                    continue;
+                } else {
+                    $this->debug("checkLinks: after checking $url");
+                }
 
                 $this->statistics->incrementCountLinksByStatus($linkTargetResponse->getStatus());
 
@@ -368,6 +373,7 @@ class LinkAnalyzer implements LoggerAwareInterface
                     }
                 } elseif ($this->configuration->isShowAllLinks()) {
                     $record['check_status'] = $linkTargetResponse->getStatus();
+                    // url_response may also contain information in case of a non-error
                     $record['url_response'] = $linkTargetResponse->toJson();
                     $record['last_check_url'] = $linkTargetResponse->getLastChecked() ?: \time();
                     $record['last_check'] = \time();

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -132,14 +132,16 @@ class LinkAnalyzer implements LoggerAwareInterface
                     $row = $this->contentRepository->getRowForUid($uid, $table, $selectFields);
                 }
 
-                $this->linkParser->findLinksForRecord(
-                    $results,
-                    $table,
-                    [$record['field']],
-                    $row,
-                    $request,
-                    LinkParser::MASK_CONTENT_CHECK_ALL
-                );
+                if ($row) {
+                    $this->linkParser->findLinksForRecord(
+                        $results,
+                        $table,
+                        [$record['field']],
+                        $row,
+                        $request,
+                        LinkParser::MASK_CONTENT_CHECK_ALL
+                    );
+                }
                 $urls = [];
                 foreach ($results[$linkType] ?? [] as $entryValue) {
                     $pageWithAnchor = $entryValue['pageAndAnchor'] ?? '';

--- a/Classes/Linktype/LinktypeInterface.php
+++ b/Classes/Linktype/LinktypeInterface.php
@@ -20,9 +20,9 @@ interface LinktypeInterface
      * @param mixed[] $softRefEntry The soft reference entry which builds the context of that url
      * @param int $flags can be a combination of flags, see flags defined in AbstractLinktype, e.g.
      *   e.g. AbstractLinktype::CHECK_LINK_FLAG_NO_CRAWL_DELAY
-     * @return LinkTargetResponse
+     * @return LinkTargetResponse|null
      */
-    public function checkLink(string $url, array $softRefEntry, int $flags = 0): LinkTargetResponse;
+    public function checkLink(string $url, array $softRefEntry, int $flags = 0): ?LinkTargetResponse;
 
     /**
      * Base type fetching method, based on the type that softRefParserObj returns.

--- a/Resources/Private/Partials/BrokenLinkList.html
+++ b/Resources/Private/Partials/BrokenLinkList.html
@@ -111,6 +111,11 @@
 					<f:if condition="{item.linktarget}">
 						<f:then>
 							<a href="{item.linktarget}" target="_blank" rel="noreferrer">{item.linktext}</a>
+							<f:if condition="{item.effectiveUrl}">
+								<br/><core:icon identifier="actions-arrow-down-right-alt" size="small" />
+								 <a href="{item.effectiveUrl}" target="_blank" rel="noreferrer" title="redirect target">{item.effectiveUrl}</a>
+								<span title="redirect count">({item.redirectCount})</span>
+							</f:if>
 							<div class="inline-action">
 								<f:if condition="{item.encoded_linktarget}">
 									<f:then>

--- a/Tests/Functional/CheckLinks/LinkTargetCache/LinkTargetPersistentCacheTest.php
+++ b/Tests/Functional/CheckLinks/LinkTargetCache/LinkTargetPersistentCacheTest.php
@@ -84,7 +84,8 @@ class LinkTargetPersistentCacheTest extends AbstractFunctional
             'exceptionMessage' => $exceptionMsg,
             'message' => $errorMessage,
             'custom' => [],
-            'reasonCannotCheck' => ''
+            'reasonCannotCheck' => '',
+            'redirects' => []
 
         ];
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -31,7 +31,7 @@ showPageLayoutButton = 1
 
 ### since TYPO3 v12
 
-# cat=checking; type=boolean;label=If an error code / type / exception matches this, the URL is non-checkable: This can be a regex if it starts with regex (separated by colon), otherwise it matches by start of string.
+# cat=checking; type=string;label=If an error code / type / exception matches this, the URL is non-checkable: This can be a regex if it starts with regex (separated by colon), otherwise it matches by start of string.
 combinedErrorNonCheckableMatch = regex:/^(httpStatusCode:(401|403):|libcurlErrno:60:SSL certificate problem: unable to get local issuer certificate)/
 
 # cat=report; type=boolean;label=Show all links, not just broken links: The default is 1 (true).


### PR DESCRIPTION
In case of external URLs, there may be one or more redirects. The redirect target is now displayed. This has the following advantages:

- provide more clarity in case of confusing response codes, such as TLS errors for http-urls
- redirects are more visible
- in case of 429 or 503, there is a mechanism to stop checking further URLs. However, this should be applied to the effective domain, not the original domain