### PR TITLE
[TASK] Make rechecking links after editing optional

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -161,6 +161,8 @@ class Configuration
 
     protected bool $showPageLayoutButton = true;
 
+    protected bool $recheckLinksOnEditing = false;
+
     /**
      * Configuration constructor.
      * @param array<mixed> $extConfArray ExtensionConfiguration array
@@ -168,6 +170,7 @@ class Configuration
     public function __construct(array $extConfArray)
     {
         // initialize from extension configuration
+        $this->recheckLinksOnEditing = (bool)($extConfArray['recheckLinksOnEditing'] ?? false);
         $this->showAllLinks = (bool)($extConfArray['showalllinks'] ?? true);
         $this->showEditButtons = ($extConfArray['showEditButtons'] ?? self::SHOW_EDIT_BUTTONS_DEFAULT_VALUE);
         $this->showPageLayoutButton = (bool)($extConfArray['showPageLayoutButton'] ?? true);
@@ -754,5 +757,10 @@ class Configuration
     public function getCustom(): array
     {
         return $this->tsConfig['custom.'] ?? [];
+    }
+
+    public function isRecheckLinksOnEditing(): bool
+    {
+        return $this->recheckLinksOnEditing;
     }
 }

--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -292,7 +292,8 @@ class BrokenLinkListController extends AbstractBrofixController
         if ($this->action === 'editField') {
             $message = '';
             // recheck broken links for last edited reccord
-            $this->linkAnalyzer->recheckLinks(
+            //$this->linkAnalyzer->recheckLinks(
+            $this->linkAnalyzer->recheckRecord(
                 $message,
                 $this->linkTypes,
                 (int)$this->currentRecord['uid'],
@@ -374,7 +375,6 @@ class BrokenLinkListController extends AbstractBrofixController
              */
             $this->hookObjectsArr[$linkType] = GeneralUtility::makeInstance($className);
         }
-
 
         $this->backendUserHasPermissionsForBrokenLinklist = false;
         if (($this->id && is_array($this->pageRecord)) || (!$this->id && $this->getBackendUser()->isAdmin())) {

--- a/composer.json
+++ b/composer.json
@@ -76,25 +76,25 @@
 			"TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
 		],
 		"ci:composerinstall": [
-			"Build/Scripts/runTests.sh -p 7.4 -s composerInstallMax"
+			"Build/Scripts/runTests.sh  -s composerInstallMax"
 		],
 		"ci:composervalidate": [
-			"Build/Scripts/runTests.sh -p 7.4 -s composerValidate"
+			"Build/Scripts/runTests.sh  -s composerValidate"
 		],
 		"ci:phpcgl:check": [
-			"Build/Scripts/runTests.sh -p 7.4 -s cgl -n"
+			"Build/Scripts/runTests.sh  -s cgl -n"
 		],
 		"ci:phpcgl:fix": [
-			"Build/Scripts/runTests.sh -p 7.4 -s cgl"
+			"Build/Scripts/runTests.sh  -s cgl"
 		],
 		"ci:cgl:check": [
 			"@ci:phpcgl:check"
 		],
 		"ci:phplint": [
-			"Build/Scripts/runTests.sh -p 7.4 -s phpstan -e \"-c ../Build/phpstan.neon\""
+			"Build/Scripts/runTests.sh  -s phpstan -e \"-c ../Build/phpstan.neon\""
 		],
 		"ci:phpstan": [
-			"Build/Scripts/runTests.sh -p 7.4 -s phpstan -e \"-c ../Build/phpstan.neon\""
+			"Build/Scripts/runTests.sh  -s phpstan -e \"-c ../Build/phpstan.neon\""
 		],
 		"rector:check": [
 			"@php .Build/bin/rector --dry-run"
@@ -103,10 +103,10 @@
 			"@php .Build/bin/rector"
 		],
 		"ci:phpunit": [
-			"Build/Scripts/runTests.sh -p 7.4 -s unit"
+			"Build/Scripts/runTests.sh  -s unit"
 		],
 		"ci:phpfunctional": [
-			"Build/Scripts/runTests.sh -p 7.4 -s functional"
+			"Build/Scripts/runTests.sh  -s functional"
 		],
 		"ci:check": [
 			"@ci:composerinstall",

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -42,3 +42,6 @@ showPageCalloutBrokenLinksExist = 1
 
 # cat=report; type=boolean; label=Use cache for page list; This is recommended for large number of pages to improve performance
 useCacheForPageList = 1
+
+# cat=checking; type=boolean; label=After editing a record, recheck links; This is NOT recommended as it may result in excessive checking and delays when editing. It is already checked if links still exist in record.
+recheckLinksOnEditing = 0


### PR DESCRIPTION
Previously all links were rechecked after editing which could cause unnecessary delays. Also, it is not always necessary since it is usually sufficient to check if the links still exist in the record on editing.

This can now be controlled with the option recheckLinksOnEditing.