### PR TITLE
Adding a specific code for Cloudflare check

### DIFF
--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -1003,11 +1003,11 @@ class BrokenLinkListController extends AbstractBrofixController
                     htmlspecialchars($languageService->sL('LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.msg.status.excluded')) ?: 'URL is excluded, will not be checked'
                 );
                 break;
-            default:
-                // todo add language label
+            default: // This case will handle LinkTargetResponse::RESULT_UNKNOWN (which is 5)
+                // todo add language label for list.msg.status.cloudflare
                 $linkMessage = sprintf(
-                    '<span class="status-unknown">%s</span>',
-                    htmlspecialchars($languageService->sL('LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.msg.status.unknown')) ?: 'Unknown status'
+                    '<span class="status-cloudflare">%s</span>', // Consider adding a specific CSS class if styling is needed
+                    htmlspecialchars($languageService->sL('LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.msg.status.cloudflare')) ?: 'Cloudflare link'
                 );
                 break;
         }

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -546,6 +546,23 @@ class LinkAnalyzer implements LoggerAwareInterface
                 }
                 $this->debug("checkLinks: after checking $url");
 
+                // Check for Cloudflare
+                $headers = $linkTargetResponse->getCustom()['headers'] ?? [];
+                $serverHeader = '';
+                if (is_array($headers)) {
+                    foreach ($headers as $headerLine) {
+                        if (is_string($headerLine) && stripos($headerLine, 'Server:') === 0) {
+                            $serverHeader = trim(substr($headerLine, strlen('Server:')));
+                            break;
+                        }
+                    }
+                }
+
+                if (stripos($serverHeader, 'cloudflare') !== false) {
+                    $linkTargetResponse->setStatus(LinkTargetResponse::RESULT_UNKNOWN);
+                    $linkTargetResponse->setReasonCannotCheck(LinkTargetResponse::REASON_CANNOT_CHECK_CLOUDFLARE);
+                }
+
                 $this->statistics->incrementCountLinksByStatus($linkTargetResponse->getStatus());
 
                 // Broken link found

--- a/Documentation/Setup/ExtensionConfigurationReference.rst
+++ b/Documentation/Setup/ExtensionConfigurationReference.rst
@@ -104,7 +104,7 @@ Currently, these are the known status:
 * 2: ok
 * 3: not possible to check ("non-checkable")
 * 4: is excluded
-* 5: The link status is unknown because the server is identified as Cloudflare.
+* 5: Cloudflare link
 
 This should also improve handling of cloudflare protected sites as these
 typically return 403 HTTP status code. The link checking status is no longer

--- a/Documentation/Setup/ExtensionConfigurationReference.rst
+++ b/Documentation/Setup/ExtensionConfigurationReference.rst
@@ -104,6 +104,7 @@ Currently, these are the known status:
 * 2: ok
 * 3: not possible to check ("non-checkable")
 * 4: is excluded
+* 5: The link status is unknown because the server is identified as Cloudflare.
 
 This should also improve handling of cloudflare protected sites as these
 typically return 403 HTTP status code. The link checking status is no longer

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ whom this work would not have been possible.
 | **Repository:**  | https://github.com/sypets/brofix                   |
 | **Read online:** | https://docs.typo3.org/p/sypets/brofix/main/en-us/ |
 | **TER:**         | https://extensions.typo3.org/extension/brofix      |
+
+## Check Status Meanings
+
+- **1 (RESULT_BROKEN):** The link is broken.
+- **2 (RESULT_OK):** The link is working.
+- **3 (RESULT_CANNOT_CHECK):** The link could not be checked (e.g., due to network issues).
+- **4 (RESULT_EXCLUDED):** The link was excluded from checking.
+- **5 (RESULT_UNKNOWN):** The link status is unknown because the server is identified as Cloudflare.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,3 @@ whom this work would not have been possible.
 | **Repository:**  | https://github.com/sypets/brofix                   |
 | **Read online:** | https://docs.typo3.org/p/sypets/brofix/main/en-us/ |
 | **TER:**         | https://extensions.typo3.org/extension/brofix      |
-
-## Check Status Meanings
-
-- **1 (RESULT_BROKEN):** The link is broken.
-- **2 (RESULT_OK):** The link is working.
-- **3 (RESULT_CANNOT_CHECK):** The link could not be checked (e.g., due to network issues).
-- **4 (RESULT_EXCLUDED):** The link was excluded from checking.
-- **5 (RESULT_UNKNOWN):** The link status is unknown because the server is identified as Cloudflare.

--- a/Resources/Private/Language/Module/locallang.xlf
+++ b/Resources/Private/Language/Module/locallang.xlf
@@ -145,6 +145,9 @@
 			<trans-unit id="list.filter.check_status.4" resname="list.filter.check_status.4">
 				<source>excluded</source>
 			</trans-unit>
+			<trans-unit id="list.filter.check_status.5" resname="list.filter.check_status.5">
+				<source>Cloudflare</source>
+			</trans-unit>
 
 			<trans-unit id="list.recheck.links.title" resname="list.recheck.links.title">
 				<source>Recheck links</source>
@@ -409,6 +412,9 @@
 			</trans-unit>
 			<trans-unit id="list.no.broken.links.filter" resname="list.no.broken.links.filter">
 				<source>No broken links found with current filter!</source>
+			</trans-unit>
+			<trans-unit id="list.msg.status.cloudflare" resname="list.msg.status.cloudflare">
+				<source>Cloudflare link</source>
 			</trans-unit>
 			<trans-unit id="no.access.title" resname="no.access.title">
 				<source>No access!</source>

--- a/Resources/Private/Partials/BrokenLinkList.html
+++ b/Resources/Private/Partials/BrokenLinkList.html
@@ -142,6 +142,7 @@
 					<f:if condition="{item.status} === 2"><core:icon identifier="actions-check-circle"/></f:if>
 					<f:if condition="{item.status} === 3"><core:icon identifier="actions-question-circle"/></f:if>
 					<f:if condition="{item.status} === 4"><core:icon identifier="actions-ban"/></f:if>
+					<f:if condition="{item.status} === 5"><core:icon identifier="actions-cloud"/></f:if>
 					{item.linkmessage -> f:format.raw()}</td>
 
 				<f:comment>==== last_check_url ====</f:comment>

--- a/Resources/Private/Partials/BrokenLinksForm.html
+++ b/Resources/Private/Partials/BrokenLinksForm.html
@@ -132,6 +132,9 @@
 				<option value="4" {f:if(condition:'{filter.checkStatusFilter} == 4', then: 'selected')}>
 				<f:translate extensionName="Brofix" key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.check_status.4"/>
 				</option>
+				<option value="5" {f:if(condition:'{filter.checkStatusFilter} == 5', then: 'selected')}>
+					<f:translate extensionName="Brofix" key="LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.filter.check_status.5"/>
+				</option>
 				<f:for each="{checkStatusOptions}" as="checkStatusOption">
 					<option value="{key}">{checkStatusOption}</option>
 				</f:for>


### PR DESCRIPTION
**Feature:** Add Cloudflare status and filter option

**Resolves** https://github.com/sypets/brofix/issues/435

- Add 'Cloudflare' (value 5) as a check_status option in the filter dropdown.
- Updated the display for items with status 5 to show 'Cloudflare link' and a cloud icon.
- Add necessary translation keys for the new labels.
- Add what the value 5 means on Documentation/Setup/ExtensionConfigurationReference.rst
- Add test for https://www.cloudflare.com to Tests/Unit/Linktype/ExternalLinktypeTest.php