### PR TITLE
[BUGFIX] Fix initialization of pagination page

### DIFF
--- a/Classes/Controller/BrokenLinkListController.php
+++ b/Classes/Controller/BrokenLinkListController.php
@@ -451,6 +451,9 @@ class BrokenLinkListController extends AbstractBrofixController
         } else {
             $this->paginationCurrentPage = 1;
         }
+        if ($this->paginationCurrentPage < 1) {
+            $this->paginationCurrentPage = 1;
+        }
     }
 
     /**


### PR DESCRIPTION
The current page for validation was sometimes set to 0 as it was fetched from the user data. It should never be 0, at least 1.

This could have caused an exception for editors.

Resolves: #470