### PR TITLE
[BUGFIX] Remove LanguageService->includeLLFile call

### DIFF
--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -65,7 +65,6 @@ class LinkAnalyzer implements LoggerAwareInterface
         protected ConnectionPool $connectionPool,
         protected Typo3Version $typo3Version
     ) {
-        $this->getLanguageService()->includeLLFile('EXT:brofix/Resources/Private/Language/Module/locallang.xlf');
         $this->brokenLinkRepository = $brokenLinkRepository;
         $this->contentRepository = $contentRepository;
         $this->pagesRepository = $pagesRepository;


### PR DESCRIPTION
This internal method vanished in TYPO3 v14 and is causing an error in the scheduler. All labels have been already migrated towards LanguageService->sL.

Related: abb4556c784efa7dab5514a3e70a61dc914b5985