### PR TITLE
[FEATURE] Resolve certificate chain

### DIFF
--- a/Classes/CheckLinks/CertificateChainResolver/AbstractCertificateChainResolver.php
+++ b/Classes/CheckLinks/CertificateChainResolver/AbstractCertificateChainResolver.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+namespace Sypets\Brofix\CheckLinks\CertificateChainResolver;
+
+use TYPO3\CMS\Core\Core\Environment;
+
+abstract class AbstractCertificateChainResolver implements CertificateChainResolverInterface
+{
+    protected string $tmpDir;
+
+    protected function getDomainForUrl(string $url): string
+    {
+        return parse_url($url, PHP_URL_HOST);
+    }
+
+    protected function initializeTmpDir(): string
+    {
+        $tmpdir = Environment::getVarPath() . '/transient';
+        if (!is_dir($tmpdir)) {
+            mkdir($tmpdir);
+        }
+        return $tmpdir;
+    }
+
+    public function getTmpDir(): string
+    {
+        if (!isset($this->tmpdir)) {
+            $this->initializeTmpDir();
+        }
+        return $this->tmpDir;
+    }
+
+    protected function getTmpDirCertFilename(string $domain): string
+    {
+        return $this->getTmpDir() . '/brofix_ssl_cert_' . $domain . '.crt';
+    }
+
+    protected function getTmpDirFullCertFilename(string $domain): string
+    {
+        return $this->getTmpDir() . '/brofix_ssl_cert_full_' . $domain . '.crt';
+    }
+
+    /**
+     * This will only fetch the cert, not necessarily the full cert chain
+     */
+    protected function fetchCert(string $domain, string $tempCertFilename): void
+    {
+        stream_context_set_default([
+            'http' => [
+                'follow_location' => 1, // Ensure redirect following is on
+                'max_redirects'   => 5, // Prevent infinite redirect loops
+                'timeout'         => 10 // Prevent script from hanging indefinitely
+            ]
+        ]);
+
+        // Open a secure stream connection directly to the port to capture context
+        $streamContext = stream_context_create([
+            'ssl' => [
+                'capture_peer_cert' => true,
+                'verify_peer'       => false, // False only here to catch the broken leaf
+                'verify_peer_name'  => false
+            ]
+        ]);
+
+        $port = 443;
+
+        $client = @stream_socket_client(
+            "ssl://{$domain}:{$port}",
+            $errno,
+            $errstr,
+            30,
+            STREAM_CLIENT_CONNECT,
+            $streamContext
+        );
+
+        if (!$client) {
+            throw new \Exception("Failed to connect to domain: $errstr ($errno)", 7470884634);
+        }
+
+        // 3. Extract the raw peer certificate resource
+        $params = stream_context_get_options($streamContext);
+        $peerCertificate = $params['ssl']['peer_certificate'] ?? '';
+        $capture_peer_cert = (bool)($params['ssl']['capture_peer_cert'] ?? false);
+
+        if (!$capture_peer_cert) {
+            throw new \Exception("Could not capture the SSL leaf certificate from {$domain}.", 3700325786);
+        }
+
+        // 4. Convert the native PHP resource into a PEM string format
+        openssl_x509_export($peerCertificate, $pemStringContents);
+
+        // save to file
+        file_put_contents($tempCertFilename, $pemStringContents);
+    }
+}

--- a/Classes/CheckLinks/CertificateChainResolver/CertificateChainResolverInterface.php
+++ b/Classes/CheckLinks/CertificateChainResolver/CertificateChainResolverInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+namespace Sypets\Brofix\CheckLinks\CertificateChainResolver;
+
+/**
+ * This interface handles fetching certiciate chains for a domain.
+ *
+ *  Objective: Implementing classes will fetch the entire certificate chain (and store it in var/transient) for a domain based on
+ *  the given URL. The underlying problem is that some servers do not provide the entire certificate chain. Qualys SSL Labs
+ *  (https://www.ssllabs.com/ssltest/analyze.html) shows this as "incomplete certificate chain" or something similar.
+ *  However, the browsers will usually resole this by fetching and caching intermediate certificates. However the curl
+ *  library (which is usually used by Guzzle in TYPO3) will not and will fail with curl error core 60 "Unable to resolve
+ *  local issuer certificate".
+ *
+ *  There is a method called  AIA Fetching (Authority Information Access) which outlines how to fetch intermediate certs.
+ * @see https://www.thesslstore.com/blog/aia-fetching/
+ *
+ * Usage: brofix will by default use the supplied implementation StayAliveCertificateChainResolver. You can provide
+ * a different implementation and must the override ExternalLinkType to use that.
+ *
+ * Configuration is in Extension Configuration (see ext_conf_template.txt) resolveCertChains. By default it is set
+ * to "intelligent", then the cert chain is only fetched on typical errors (libcurl errno=60). It can also be set
+ * to "always" or "never"
+ */
+interface CertificateChainResolverInterface
+{
+    /**
+     * Resolves cert chain, writes to file and returns path name
+     */
+    public function resolveCertChain(string $url, bool $onlyForHttpsUrls = false): string;
+}

--- a/Classes/CheckLinks/CertificateChainResolver/StayAliveCertificateChainResolver.php
+++ b/Classes/CheckLinks/CertificateChainResolver/StayAliveCertificateChainResolver.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+namespace Sypets\Brofix\CheckLinks\CertificateChainResolver;
+
+use TYPO3\CMS\Core\Core\Environment;
+
+/**
+ * This class handles fetching certiciate chains for a domain.
+ *
+ * This class requires the package:
+ * stayallive/certificate-chain-resolver
+ *
+ *  Objective: this class will fetch the entire certificate chain (and store it in var/transient) for a domain based on
+ *  the given URL. The underlying problem is that some servers do not provide the entire certificate chain. Qualys SSL Labs
+ *  (https://www.ssllabs.com/ssltest/analyze.html) shows this as "incomplete certificate chain" or something similar.
+ *  However, the browsers will usually resolve this by fetching and caching intermediate certificates. However the curl
+ *  library (which is usually used by Guzzle in TYPO3) will not and will fail with curl error core 60 "Unable to resolve
+ *  local issuer certificate".
+ *
+ *  There is a method called  AIA Fetching (Authority Information Access) which outlines how to fetch intermediate certs.
+ * @see https://www.thesslstore.com/blog/aia-fetching/
+ *
+ * Usage:
+ *   By default, this class will be used in ExternalLinktype.
+ *
+ *   Configuration is in Extension Configuration (see ext_conf_template.txt) resolveCertChains. By default it is set
+ *   to "intelligent", then the cert chain is only fetched on typical errors (libcurl errno=60). It can also be set
+ *   to "always" or "never"
+ *
+ * @todo Should we follow redirects and possibly get certificates for the targets as well?
+ */
+class StayAliveCertificateChainResolver extends AbstractCertificateChainResolver
+{
+    /**
+     * Fetch cert chain for URL and store to local path
+     */
+    public function resolveCertChain(string $url, bool $onlyForHttpsUrls = false): string
+    {
+        if (!class_exists('\Stayallive\CertificateChain\Certificate')
+            || !class_exists('\Stayallive\CertificateChain\Resolver')) {
+            return '';
+        }
+
+        if ($onlyForHttpsUrls && !str_starts_with($url, 'https://')) {
+            // no https, do nothing
+            return '';
+        }
+        $domain =  $this->getDomainForUrl($url);
+
+        $tmpdir = $this->getTmpDir();
+
+        $tempCertFilename = $this->getTmpDirCertFilename($domain);
+        $tempCertfullChainFilename = $this->getTmpDirFullCertFilename($domain);
+
+        if (file_exists($tempCertfullChainFilename)) {
+            return $tempCertfullChainFilename;
+        }
+
+        $this->fetchCert($domain, $tempCertFilename);
+
+        $this->resolveCert($domain, $tempCertFilename, $tempCertfullChainFilename);
+
+        return $tempCertfullChainFilename;
+    }
+
+    protected function resolveCert(string $domain, string $tempCertFilename, string $tempCertfullChainFilename): void
+    {
+        // 5. Load the PEM string instead of the URL string directly into the resolver
+        $certificate = \Stayallive\CertificateChain\Certificate::loadFromPathOrUrl($tempCertFilename);
+        $resolver = new \Stayallive\CertificateChain\Resolver($certificate);
+
+        // 6. Get your finalized complete chain
+        $fullChainText = $resolver->getContents();
+
+        // 7. Save locally for your Guzzle application environment
+        file_put_contents($tempCertfullChainFilename, $fullChainText);
+    }
+}

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -68,6 +68,11 @@ class Configuration
     public const BEHAVIOR_ON_CHECK_INTELLIGENT = 'intelligent';
     public const BEHAVIOR_ON_CHECK_DEFAULT = self::BEHAVIOR_ON_CHECK_INTELLIGENT;
 
+    public const RESOLVE_CERT_CHAINS_ALWAYS = 'always';
+    public const RESOLVE_CERT_CHAINS_NEVER = 'never';
+    public const RESOLVE_CERT_CHAINS_INTELLIGENT = 'intelligent';
+    public const RESOLVE_CERT_CHAINS_DEFAULT = self::RESOLVE_CERT_CHAINS_INTELLIGENT;
+
     public const DEFAULT_TSCONFIG = [
         'searchFields.' => [
             'pages' => 'media,url',
@@ -186,6 +191,8 @@ class Configuration
     protected int $showUrlChecker = self::SHOW_URL_CHECKER_DEFAULT;
 
     protected string $behaviourOnCheckError = self::BEHAVIOR_ON_CHECK_DEFAULT;
+
+    protected string $resolveCertChains = self::RESOLVE_CERT_CHAINS_DEFAULT;
 
     /**
      * Configuration constructor.
@@ -847,5 +854,30 @@ class Configuration
     public function setBehaviourOnCheckError(string $behaviourOnCheckError): void
     {
         $this->behaviourOnCheckError = $behaviourOnCheckError;
+    }
+
+    public function getResolveCertChains(): string
+    {
+        return $this->resolveCertChains;
+    }
+
+    public function setResolveCertChains(string $resolveCertChains): void
+    {
+        $this->resolveCertChains = $resolveCertChains;
+    }
+
+    public function isResolveCertChainAlways(): bool
+    {
+        return $this->resolveCertChains === self::RESOLVE_CERT_CHAINS_ALWAYS;
+    }
+
+    public function isResolveCertChainNever(): bool
+    {
+        return $this->resolveCertChains === self::RESOLVE_CERT_CHAINS_NEVER;
+    }
+
+    public function isResolveCertChainIntelligent(): bool
+    {
+        return $this->resolveCertChains === self::RESOLVE_CERT_CHAINS_INTELLIGENT;
     }
 }

--- a/Classes/LinkAnalyzer.php
+++ b/Classes/LinkAnalyzer.php
@@ -688,6 +688,7 @@ class LinkAnalyzer implements LoggerAwareInterface
                     );
 
                 $result = $queryBuilder->executeQuery();
+                $processed = 0;
                 while ($row = $result->fetchAssociative()) {
                     $results = [];
                     $idRecord = (int)($row['uid'] ?? 0);

--- a/Classes/Linktype/ExternalLinktype.php
+++ b/Classes/Linktype/ExternalLinktype.php
@@ -14,6 +14,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Sypets\Brofix\CheckLinks\CertificateChainResolver\CertificateChainResolverInterface;
+use Sypets\Brofix\CheckLinks\CertificateChainResolver\StayAliveCertificateChainResolver;
 use Sypets\Brofix\CheckLinks\CrawlDelay;
 use Sypets\Brofix\CheckLinks\ExcludeLinkTarget;
 use Sypets\Brofix\CheckLinks\LinkTargetCache\LinkTargetCacheInterface;
@@ -84,6 +86,11 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
     protected $crawlDelay;
 
     /**
+     * @var CertificateChainResolverInterface
+     */
+    protected $certificateChainResolver;
+
+    /**
      * @var array<int,array{from:string, to:string}>
      */
     protected array $redirects = [];
@@ -95,12 +102,14 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
         ?RequestFactory $requestFactory = null,
         ?ExcludeLinkTarget $excludeLinkTarget = null,
         ?LinkTargetCacheInterface $linkTargetCache = null,
-        ?CrawlDelay $crawlDelay = null
+        ?CrawlDelay $crawlDelay = null,
+        ?CertificateChainResolverInterface $certificateChainResolver = null,
     ) {
         $this->requestFactory = $requestFactory ?: GeneralUtility::makeInstance(RequestFactory::class);
         $this->excludeLinkTarget = $excludeLinkTarget ?: GeneralUtility::makeInstance(ExcludeLinkTarget::class);
         $this->linkTargetCache = $linkTargetCache ?: GeneralUtility::makeInstance(LinkTargetPersistentCache::class);
         $this->crawlDelay = $crawlDelay ?: GeneralUtility::makeInstance(CrawlDelay::class);
+        $this->certificateChainResolver = $certificateChainResolver ?: GeneralUtility::makeInstance(StayAliveCertificateChainResolver::class);
     }
 
     public function setConfiguration(Configuration $configuration): void
@@ -223,8 +232,37 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
                 }
             }
 
+            // resolve cert chain based on config
+            $resolveCertChain = false;
+            $resolveChainOnlyForHTTPSOnly = false;
+            if ($this->configuration->isResolveCertChainAlways()) {
+                $resolveCertChain = true;
+                /** since we always resolve cert chain we should do it only for HTTPS urls because some sites may
+                 * not have HTTPS support
+                 */
+                $resolveChainOnlyForHTTPSOnly = true;
+            }
+            if ($resolveCertChain) {
+                $certChainFile = $this->certificateChainResolver->resolveCertChain($url, $resolveChainOnlyForHTTPSOnly);
+                if ($certChainFile) {
+                    $options['verify'] = $certChainFile;
+                }
+            }
+
             // first check HEAD and if ERROR, also check GET
             $linkTargetResponse = $this->requestUrl($url, 'HEAD', $options);
+            // if certChainResolving is set to intelligent, only apply it if libcurlerror and errno=60
+            if (!$resolveCertChain && $this->configuration->isResolveCertChainIntelligent()
+                && $linkTargetResponse->isError()
+                && $linkTargetResponse->getErrorType() === self::ERROR_TYPE_LOWLEVEL_LIBCURL_ERRNO
+                && $linkTargetResponse->getErrno() === 60
+            ) {
+                $resolveCertChain = true;
+                $certChainFile = $this->certificateChainResolver->resolveCertChain($url, $resolveChainOnlyForHTTPSOnly);
+                if ($certChainFile) {
+                    $options['verify'] = $certChainFile;
+                }
+            }
             if ($linkTargetResponse->isError()) {
                 // HEAD was not allowed or threw an error, now trying GET
                 $options['headers']['Range'] = 'bytes=0-4048';
@@ -251,6 +289,7 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
         $responseHeaders = [];
         try {
             $this->redirects = [];
+
             $response = $this->requestFactory->request($url, $method, $options);
 
             if ($response->getStatusCode() >= 300) {
@@ -470,9 +509,16 @@ class ExternalLinktype extends AbstractLinktype implements LoggerAwareInterface
 
             case self::ERROR_TYPE_LOWLEVEL_LIBCURL_ERRNO:
                 $message = '';
-                if ($errno > 0) {
+                if ($errno > 0 && $errno != 60) {
                     // get localized error message
                     $message = $lang->sL('LLL:EXT:brofix/Resources/Private/Language/Module/locallang.xlf:list.report.error.libcurl.' . $errno);
+                }
+                /**
+                 * Temporary workaround to show the original exception message for erroor code 60, needs better handling in the future
+                 * @see https://github.com/sypets/brofix/issues/493
+                 */
+                if ($errno === 60) {
+                    $message = $exception;
                 }
                 if (!$message) {
                     // fallback to  generic error message and show exception

--- a/Documentation/Changelog/Entries/7.x.x/494-Feature-ResolveCertChain.rst
+++ b/Documentation/Changelog/Entries/7.x.x/494-Feature-ResolveCertChain.rst
@@ -1,0 +1,51 @@
+.. include:: /Includes.rst.txt
+
+===================================
+Feature - Resolve Certificate Chain
+===================================
+
+*since verion 7.1.0*
+
+`Link to Issue 486 <https://github.com/sypets/brofix/issues/494>`
+
+This introduces a new class StayAliveCertificateChainResolver to resolve
+certificate chains. This is relevant only for external links with HTTPS.0
+
+This class requires the package stayallive/certificate-chain-resolver (which is
+now required in composer.json).
+
+Objective: this class will fetch the entire certificate chain (and store it in
+var/transient) for a domain based on the given URL. The underlying problem is
+that some servers do not provide the entire certificate chain. Qualys SSL Labs
+(https://www.ssllabs.com/ssltest/analyze.html) shows this as "incomplete
+certificate chain" or something similar. However, the browsers will usually
+resolve this by fetching and caching intermediate certificates. However the curl
+library (which is usually used by Guzzle in TYPO3) will not and will fail with
+curl error core 60 "Unable to resolve local issuer certificate".
+
+There is a method called  AIA Fetching (Authority Information Access) which outlines how to fetch intermediate certs.
+@see https://www.thesslstore.com/blog/aia-fetching/
+
+Usage
+=====
+ By default, this class will be used in ExternalLinktype.
+
+ Configuration is in Extension Configuration (see ext_conf_template.txt)
+ resolveCertChains. By default it is set to "intelligent": the cert chain is
+ only fetched on typical errors (libcurl errno=60). It can also be set
+ to "always" or "never"
+
+Impact
+======
+
+Possibly fixes problems with external links with incomple certificate chain.
+
+URLs which had this problem and previously showed an error in brofix
+(false positives) should now be displayed with status "ok".
+
+Migration
+=========
+
+Do a rechecking on affected URLs. This is not strictly necessary, it is also
+possible to wait until the cache expires for these URLs.
+

--- a/Tests/Unit/AbstractUnit.php
+++ b/Tests/Unit/AbstractUnit.php
@@ -24,6 +24,9 @@ abstract class AbstractUnit extends UnitTestCase
         'excludeSoftrefs' => 'url',
         'excludeSoftrefsInFields' => 'tt_content.bodytext',
         'traverseMaxNumberOfPagesInBackend' => 100,
+
+        // disable certificate chain resolving
+        'resolveCertChains' => 'never'
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
 	},
 	"require": {
 		"php": "^8.2",
+		"stayallive/certificate-chain-resolver": "^1.0",
 		"typo3/cms-backend": "^13.4 || ^14",
 		"typo3/cms-core": "^13.4 || ^14",
 		"typo3/cms-fluid": "^13.4 || ^14",

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -7,6 +7,9 @@
 
 ### checking ###
 
+# cat=checking; type=options[never=never,always=always,intelligent=intelligent]; label=Whether to reolve cert chains (fetching intermediate certificates), this may reduce the number of false-positives with external links
+resolveCertChains = intelligent
+
 # cat=checking; type=options[continue=continue,abort=abort,intelligent=intelligent]; label=How to handle errors and exceptions: Continue (and log error) on or throw exception and aborting? To continue will prioritize finishing the check but possibly obscure errors. Default is "intelligents" where brofix decides on case by case basis.
 behaviourOnCheckError = intelligent
 
@@ -29,7 +32,7 @@ linkTargetCacheExpiresLow = 0
 linkTargetCacheExpiresHigh = 0
 
 # cat=checking; type=string;label=If an error code / type / exception matches this, the URL is non-checkable: This can be a regex if it starts with regex (separated by colon), otherwise it matches by start of string.
-combinedErrorNonCheckableMatch = regex:/^(httpStatusCode:(401|403):|libcurlErrno:60:SSL certificate problem: unable to get local issuer certificate)/
+combinedErrorNonCheckableMatch = regex:/^(httpStatusCode:(401|403):|libcurlErrno:60:SSL certificate problem: Not existing error as example)/
 
 # cat=checking; type=boolean; label=After editing a record, recheck links; This is NOT recommended as it may result in excessive checking and delays when editing. It is already checked if links still exist in record.
 recheckLinksOnEditing = 0

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,7 +10,8 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => '',
     'state' => 'stable',
     // already incremented major version because of upgrade wizard
-    'version' => '7.0.1-dev',
+    // already imcremented minor version to 7.1 due to certificate chain resolver
+    'version' => '7.1.0-dev',
     'constraints' => [
         'depends' => [
             'typo3' => '13.4.0-14.4.99',


### PR DESCRIPTION
In order to reduce false positives where the certificate chain could not be fully resolved, we try to resolve cert chain automatically using the package stayallive/certificate-chain-resolver.

Resolves: #494

----

todos

* [x] Move functionality to extra class using generic interface for more flexibility
* [x] make configurable: no resolving, always resolve, only resolve if first check fails
* [x] add changelog and documentation