### PR TITLE
[BUGFIX] Avoid exception on unsent mail

### DIFF
--- a/Classes/Command/CheckLinksCommand.php
+++ b/Classes/Command/CheckLinksCommand.php
@@ -373,16 +373,20 @@ class CheckLinksCommand extends Command
                     break;
                 case Configuration::SEND_EMAIL_ALWAYS:
                     $this->io->writeln('Send email');
-                    $this->generateCheckResultMail->generateMail($this->configuration, $this->statistics[$pageId], $pageId);
+                    if (!$this->generateCheckResultMail->generateMail($this->configuration, $this->statistics[$pageId], $pageId)) {
+                        $this->io->error('Error sending mail: ' . $this->generateCheckResultMail->getErrorMessage());
+                    }
                     break;
                 case Configuration::SEND_EMAIL_ANY:
                     if ($stats->getCountBrokenLinks()) {
                         $this->io->writeln('Broken links found, send email');
-                        $this->generateCheckResultMail->generateMail(
+                        if (!$this->generateCheckResultMail->generateMail(
                             $this->configuration,
                             $this->statistics[$pageId],
                             $pageId
-                        );
+                        )) {
+                            $this->io->error('Error sending mail: ' . $this->generateCheckResultMail->getErrorMessage());
+                        }
                     } else {
                         $this->io->writeln('No broken links found, do not send email');
                     }
@@ -392,11 +396,13 @@ class CheckLinksCommand extends Command
                     $newBrokenLinks = $stats->getCountNewBrokenLinks();
                     if ($newBrokenLinks) {
                         $this->io->writeln($newBrokenLinks . ' new broken links found, send email');
-                        $this->generateCheckResultMail->generateMail(
+                        if (!$this->generateCheckResultMail->generateMail(
                             $this->configuration,
                             $this->statistics[$pageId],
                             $pageId
-                        );
+                        )) {
+                            $this->io->error('Error sending mail: ' . $this->generateCheckResultMail->getErrorMessage());
+                        }
                     } else {
                         $this->io->writeln('No new broken links found, do not send email');
                     }

--- a/Classes/Mail/GenerateCheckResultFluidMail.php
+++ b/Classes/Mail/GenerateCheckResultFluidMail.php
@@ -28,7 +28,8 @@ class GenerateCheckResultFluidMail implements SingletonInterface
     /**
      * @var string
      */
-    protected $messageId;
+    protected $messageId = '';
+    protected string $errorMessage = '';
 
     public function __construct(protected readonly LoggerInterface $logger)
     {
@@ -83,6 +84,8 @@ class GenerateCheckResultFluidMail implements SingletonInterface
     {
         $templatePaths = new TemplatePaths($GLOBALS['TYPO3_CONF_VARS']['MAIL']);
 
+        $this->errorMessage = '';
+
         /**
          * @var FluidEmail
          */
@@ -124,6 +127,7 @@ class GenerateCheckResultFluidMail implements SingletonInterface
         if ($subject) {
             $fluidEmail->subject($subject);
         }
+        $hasSentMessage = false;
 
         try {
             $this->mailer->send($fluidEmail);
@@ -136,29 +140,34 @@ class GenerateCheckResultFluidMail implements SingletonInterface
                     $pageId
                 )
             );
+            $hasSentMessage = true;
         } catch (\Throwable $e) {
-            $this->logger->error(
-                sprintf(
-                    'Exception sending mail Exception message=<%s> to=<%s> from=<%s> subject=<%s> pageId=<%d>',
-                    $e->getMessage(),
-                    $this->convertEmailAdressesToString($recipients),
-                    $from,
-                    $subject,
-                    $pageId
-                )
+            $this->errorMessage = sprintf(
+                'Exception sending mail Exception message=<%s> to=<%s> from=<%s> subject=<%s> pageId=<%d>',
+                $e->getMessage(),
+                $this->convertEmailAdressesToString($recipients),
+                $from,
+                $subject,
+                $pageId
             );
+
             if ($config->getBehaviourOnCheckError() === Configuration::BEHAVIOR_ON_CHECK_ABORT) {
                 throw $e;
             }
+            $this->logger->error(
+                $this->errorMessage
+            );
         }
 
-        /**
-         * @var SentMessage
-         */
-        $sentMessage = $this->mailer->getSentMessage();
-        $this->messageId = $sentMessage->getMessageId();
-
-        return true;
+        if ($hasSentMessage) {
+            /**
+             * @var SentMessage
+             */
+            $sentMessage = $this->mailer->getSentMessage();
+            $this->messageId = $sentMessage->getMessageId();
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -175,5 +184,10 @@ class GenerateCheckResultFluidMail implements SingletonInterface
             return '';
         }
         return implode(', ', $adresses);
+    }
+
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage;
     }
 }


### PR DESCRIPTION
Due to new behaviour on errors, brofix might continue during cli checking and sending mail, even if mail was not sent (e.g. due to configuration error). This might have resulten in exception further down in case of uninitialized arguments. This is now properly handled.