### PR TITLE
[TASK] Remove workaround for mail-logger

### DIFF
--- a/Classes/Mail/GenerateCheckResultFluidMail.php
+++ b/Classes/Mail/GenerateCheckResultFluidMail.php
@@ -10,11 +10,9 @@ use Symfony\Component\Mime\Address;
 use Sypets\Brofix\CheckLinks\CheckLinksStatistics;
 use Sypets\Brofix\Configuration\Configuration;
 use Sypets\Brofix\Exceptions\MissingConfigurationException;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Mail\FluidEmail;
 use TYPO3\CMS\Core\Mail\Mailer;
 use TYPO3\CMS\Core\SingletonInterface;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\View\TemplatePaths;
 
@@ -23,48 +21,14 @@ use TYPO3\CMS\Fluid\View\TemplatePaths;
  */
 class GenerateCheckResultFluidMail implements SingletonInterface
 {
-    protected Mailer $mailer;
-
     /**
      * @var string
      */
     protected $messageId = '';
     protected string $errorMessage = '';
 
-    public function __construct(protected readonly LoggerInterface $logger)
+    public function __construct(protected readonly LoggerInterface $logger, protected Mailer $mailer)
     {
-        $this->mailer = $this->instantiateMailer();
-    }
-
-    /**
-     * Consider different constructor of pluswerk/mail-logger MailerExtender (which XCLASSes Mailer)
-     */
-    protected function instantiateMailer(): Mailer
-    {
-        $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
-        if ($typo3Version->getMajorVersion() > 12
-            && ExtensionManagementUtility::isLoaded('mail_logger')
-            && isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][Mailer::class]['className'])
-            /**
-             * even in a plain PHP file where it works, ::class doesn't require the class to exist - it just
-             * resolves the name based on the current namespace and use statements, and substitutes in the resulting string
-             *
-             * Use string here because otherwise phpstan will complain.
-             */
-            && $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][Mailer::class]['className'] === 'Pluswerk\\MailLogger\\Logging\\MailerExtender'
-        ) {
-            /** @phpstan-ignore-next-line  */
-            $loggingTransportFactory = GeneralUtility::makeInstance('Pluswerk\\MailLogger\\Logging\\LoggingTransportFactory');
-            /** @phpstan-ignore-next-line  */
-            if (!$loggingTransportFactory) {
-                $this->logger->error('Could not instantiate pluswerk/mail_logger: LoggingTransportFactory');
-                throw new \RuntimeException('Could not instantiate pluswerk/mail_logger: LoggingTransportFactory', 4056014818);
-            }
-            $mailer = GeneralUtility::makeInstance(Mailer::class, $loggingTransportFactory);
-        } else {
-            $mailer = GeneralUtility::makeInstance(Mailer::class);
-        }
-        return $mailer;
     }
 
     public function getMessageId(): string

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
 		"sypets/page-callouts": "^3.0.0"
 	},
 	"conflict": {
-		"typo3/cms": "*"
+		"typo3/cms": "*",
+		"pluswerk/mail-logger": "<5.0.6"
 	},
 	"extra": {
 		"typo3/cms": {


### PR DESCRIPTION
Due to some possible complications with pluswerk/mail-logger in previous versions, a workaround for using Mailer was applied to brofix.

This can now be removed for versions >= 5.0.6 of pluswerk/mail-logger.

In order to clean up the code, we can add a conflict statement for older versions to composer.json