### PR TITLE
[FEATURE] Add option for showPageCalloutBrokenLinksExist

### DIFF
--- a/Classes/Hooks/PageCalloutsHook.php
+++ b/Classes/Hooks/PageCalloutsHook.php
@@ -11,9 +11,17 @@ use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper;
 
+/**
+ * Show broken links in page module.
+ *
+ * Requirements:
+ * - sypets/page-callouts installed
+ * - extension configuration showPageCalloutBrokenLinksExist is 2
+ *   or showPageCalloutBrokenLinksExist is 1 and user setting tx_brofix_showPageCalloutBrokenLinksExist is 1
+ */
 class PageCalloutsHook implements SingletonInterface
 {
-    protected bool $showPageCalloutBrokenLinksExist = false;
+    protected int $showPageCalloutBrokenLinksExist = 1;
 
     public function __construct(
         protected BrokenLinkRepository $brokenLinkRepository,
@@ -21,7 +29,7 @@ class PageCalloutsHook implements SingletonInterface
         protected readonly UriBuilder $uriBuilder
     ) {
         $extensionConfigurationArray = $extensionConfiguration->get('brofix');
-        $this->showPageCalloutBrokenLinksExist = (bool)($extensionConfigurationArray['showPageCalloutBrokenLinksExist'] ?? true);
+        $this->showPageCalloutBrokenLinksExist = (int)($extensionConfigurationArray['showPageCalloutBrokenLinksExist'] ?? 1);
     }
 
     /**
@@ -32,9 +40,26 @@ class PageCalloutsHook implements SingletonInterface
      */
     public function addMessages(array $pageInfo): array
     {
-        // check extension configuration
-        if (!$this->showPageCalloutBrokenLinksExist) {
+        /** @var BackendUserAuthentication $beUser */
+        $beUser = $GLOBALS['BE_USER'];
+        if (!$beUser->isAdmin() && !$beUser->check('modules', 'web_brofix')) {
+            // no output in case the user does not have access to the "brofix" module
             return [];
+        }
+
+        // check extension configuration:
+        // if 0: do not show
+        // if 1: only show if user setting is also true
+        // if 2 : always show
+        switch ($this->showPageCalloutBrokenLinksExist) {
+            case 0:
+                return [];
+            case 1:
+                if (((bool)($beUser->uc['tx_brofix_showPageCalloutBrokenLinksExist'] ?? true)) === false) {
+                    // do not show broken links in page module
+                    return [];
+                }
+                // case 2: continue
         }
 
         if (!$pageInfo) {
@@ -42,17 +67,6 @@ class PageCalloutsHook implements SingletonInterface
         }
         $pageId = (int)($pageInfo['uid']);
         if ($pageId === 0) {
-            return [];
-        }
-
-        /** @var BackendUserAuthentication $beUser */
-        $beUser = $GLOBALS['BE_USER'];
-        if (!$beUser->isAdmin() && !$beUser->check('modules', 'web_brofix')) {
-            // no output in case the user does not have access to the "brofix" module
-            return [];
-        }
-        // check user settings (default is 1)
-        if (((bool)($beUser->uc['tx_brofix_showPageCalloutBrokenLinksExist'] ?? true)) === false) {
             return [];
         }
 

--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -5,8 +5,9 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
-
-if ($typo3Version->getMajorVersion() >= 14) {
+// directly access extension configuration so class does not need to be initialized
+$showPageCalloutBrokenLinksExist = (int)($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['showPageCalloutBrokenLinksExist'] ?? 1);
+if ($showPageCalloutBrokenLinksExist === 1 && $typo3Version->getMajorVersion() >= 14) {
     /**
      * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Deprecation-108843-ExtensionManagementUtilityAddFieldsToUserSettings.html
      */

--- a/Documentation/Changelog/Entries/6.0.0-6.1.x/Feature-MakePageCalloutsConfigurable.rst
+++ b/Documentation/Changelog/Entries/6.0.0-6.1.x/Feature-MakePageCalloutsConfigurable.rst
@@ -4,21 +4,26 @@
 Feature - Make page callouts configurable
 ===========================================
 
-*since verion 6.1.0*
+*since verion 6.1.0, changed again in 8.0.1*
 
 If `EXT:page_callouts <https://extensions.typo3.org/extension/page_callouts>`__
 is installed, information is displayed in the page module, if broken links exists.
 
 Since this has a small performance impact, is not really necessary if broken
-links are fixed regularly etc., this is now configurable via:
+links are fixed regularly.
 
-*  extension configuration: "Show message in page module if broken links exist on page" *[showPageCalloutBrokenLinksExist]* (default: on)
+This is now configurable via:
+
+*  extension configuration: "Show message in page module if broken links exist
+   on page" *[showPageCalloutBrokenLinksExist]* (default: "depends on user settings")
 *  user settings: "Show message in page module if broken links exist on page"
-   *[tx_brofix_showPageCalloutBrokenLinksExist]* in tab "Broken links" (default: on)
+   *[tx_brofix_showPageCalloutBrokenLinksExist]* in tab "Broken links" (default: on),
+   only available if extension configuration showPageCalloutBrokenLinksExist is
+   set to "depends on user settings".
 
-The information is **only** displayed if extension configuration is set to true,
-the user settings is active and page_callouts is installed (and of course, if
-broken links exist on that page).
+The information is **only** displayed if extension configuration is set to "Always"
+or "depends on user settings" and the user settings is active.
+Additionally, page_callouts mubst be installed.
 
 Migration
 =========

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -68,5 +68,5 @@ showUrlChecker = 0
 
 ### page module ###
 
-# cat=page module; type=boolean;label=Show message in page module if broken links exist on page: Has small performance impact, requires the extension page_callouts, can be further configured in BE user settings
+# cat=page module; type=options[Never=0, Depends on user settings=1, Always=2];label=Show message in page module if broken links exist on page: Has small performance impact, requires the extension page_callouts, can be further configured in BE user settings
 showPageCalloutBrokenLinksExist = 1

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -8,7 +8,13 @@ defined('TYPO3') or die();
 
 $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
 
-if ($typo3Version->getMajorVersion() < 14) {
+/**
+ * is moved to Configuration/TCA/Overrides/be_users.php for TYPO3 >= v14
+ * @todo Remove here when support for TYPO3 v13 is dropped
+ */
+// directly access extension configuration so class does not need to be initialized
+$showPageCalloutBrokenLinksExist = (int)($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['brofix']['showPageCalloutBrokenLinksExist'] ?? 1);
+if ($showPageCalloutBrokenLinksExist === 1 && $typo3Version->getMajorVersion() < 14) {
     // BE user settings
     // ----------------
 
@@ -17,7 +23,7 @@ if ($typo3Version->getMajorVersion() < 14) {
     $GLOBALS['TYPO3_USER_SETTINGS']['columns']['tx_brofix_showPageCalloutBrokenLinksExist'] = [
         'label' => $lll . ':usersettings.pagemodule.showPageCalloutBrokenLinksExist',
         'type' => 'check',
-        'default' => '0',
+        'default' => '1',
     ];
     ExtensionManagementUtility::addFieldsToUserSettings(
         '--div--;' . $lll . ':usersettings.brofix.tab,tx_brofix_showPageCalloutBrokenLinksExist',


### PR DESCRIPTION
There are now 3 options for extension configuration showPageCalloutBrokenLinksExist ("Show message in
page module if broken links exist on page")

- Never
- Depends on user settings
- Always

Only if it is set to "Depends on user settings", is it possible to change the setting in the user settings.

This influeces whether broken links are displayed in the page module (requires page_callouts).